### PR TITLE
Implement proper vm name passing

### DIFF
--- a/api/admin/admin.proto
+++ b/api/admin/admin.proto
@@ -33,6 +33,7 @@ message RegistryResponse {
 
 message ApplicationRequest {
     string AppName = 1;
+    optional string VmName = 2;
 }
 
 message ApplicationResponse {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -76,12 +76,8 @@ impl AdminClient {
         Ok(response.into_inner().cmd_status)
     }
 
-    pub async fn start(&self, app: String, vm: Option<String>) -> anyhow::Result<()> {
-        let app_name = match vm {
-            Some(vm_name) => format!("{app}:{vm_name}"),
-            None => app,
-        };
-        let request = pb::admin::ApplicationRequest { app_name };
+    pub async fn start(&self, app_name: String, vm_name: Option<String>) -> anyhow::Result<()> {
+        let request = pb::admin::ApplicationRequest { app_name, vm_name };
         let response = self.connect_to().await?.start_application(request).await?;
         // Ok(response.into_inner().cmd_status)
         Ok(())

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
                 ];
               };
             in
-            {
+            rec {
               givc-app = pkgs.callPackage ./nixos/packages/givc-app.nix { inherit src; };
               givc-agent = pkgs.callPackage ./nixos/packages/givc-agent.nix { inherit src; };
               givc-admin = pkgs.callPackage ./nixos/packages/givc-admin.nix { inherit src; };
@@ -69,6 +69,7 @@
                 inherit crane;
                 src = ./.;
               };
+              givc-cli = givc-admin-rs.cli;
             };
         };
       flake = {
@@ -83,8 +84,8 @@
 
         # Overlays
         overlays.default = _final: prev: {
-          src = ./.;
-          givc-app = prev.callPackage ./nixos/packages/givc-app.nix { pkgs = prev; };
+          inherit (self.packages.${prev.stdenv.hostPlatform.system}) givc-app;
+          givc-cli = self.packages.${prev.stdenv.hostPlatform.system}.givc-admin-rs.cli;
         };
       };
     };

--- a/nixos/packages/givc-admin-rs.nix
+++ b/nixos/packages/givc-admin-rs.nix
@@ -30,6 +30,11 @@ let
   givc = craneLib.buildPackage (
     commonArgs
     // {
+      outputs = [
+        "out"
+        "cli"
+        "agent"
+      ];
       cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
       # Additional environment variables or build phases/hooks can be set
@@ -38,6 +43,11 @@ let
       postUnpack = ''
         # Avoid issue with source filtering, put symlink back into source tree
         ln -sf ../api $sourceRoot/common/api
+      '';
+      postInstall = ''
+        mkdir -p $cli/bin $agent/bin
+        mv $out/bin/givc-cli $cli/bin/givc-cli
+        mv $out/bin/givc-agent $agent/bin/givc-agent
       '';
     }
   );

--- a/nixos/tests/admin.nix
+++ b/nixos/tests/admin.nix
@@ -207,7 +207,7 @@ in
           testScript =
             { nodes, ... }:
             let
-              cli = "${self'.packages.givc-admin-rs}/bin/givc-cli";
+              cli = "${self'.packages.givc-admin-rs.cli}/bin/givc-cli";
               expected = "givc-ghaf-host.service"; # Name which we _expect_ to see registered in admin server's registry
             in
             # FIXME: why it so bizzare? (derived from name in cert)

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -231,19 +231,12 @@ impl AdminServiceImpl {
         self.registry.register(entry)
     }
 
-    fn parse_app_vm_pair(app_and_vm: &str) -> (&str, Option<&str>) {
-        if let Some((app, vm)) = app_and_vm.split_once(":") {
-            (app, Some(vm))
-        } else {
-            (app_and_vm, None)
-        }
-    }
-
     pub async fn start_app(&self, req: ApplicationRequest) -> anyhow::Result<()> {
         if self.state != State::VmsRegistered {
             info!("not all required system-vms are registered")
         }
-        let (name, vm) = Self::parse_app_vm_pair(&req.app_name);
+        let name = req.app_name;
+        let vm = req.vm_name.as_deref();
         let vm_name = format_vm_name(&name, vm);
         let systemd_agent = format_service_name(&name, vm);
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
Implement proper vm name passing

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Test procedure added to nixos/tests
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing

`nix flake check` or `run-vm-test admin`.

`givc-cli .... start --vm vmname appname` should start in `vmname` VM