### PR TITLE
u8 values for enums VMStatus and TrustLevel

### DIFF
--- a/common/src/query.rs
+++ b/common/src/query.rs
@@ -10,19 +10,21 @@ use serde::Serialize;
 use strum::{Display, EnumString};
 
 #[derive(Clone, Copy, Debug, Default, Serialize, EnumString, Display)]
+#[repr(u8)]
 pub enum VMStatus {
     #[default]
-    Running,
-    PoweredOff,
-    Paused,
+    Running = 0,
+    PoweredOff = 1,
+    Paused = 2,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, EnumString, Display)]
+#[repr(u8)]
 pub enum TrustLevel {
-    Secure,
+    Secure = 0,
     #[default]
-    Warning,
-    NotSecure,
+    Warning = 1,
+    NotSecure = 2,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
u8 values for enums VMStatus and TrustLevel 

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
Ensure each variant of enum VMStatus and TrustLevel has a specific discriminant value (for better compatibility).


## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [X] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [X] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
