### PR TITLE
Add multiple addresses to admin nixos module

### DIFF
--- a/nixos/tests/dbus.nix
+++ b/nixos/tests/dbus.nix
@@ -16,12 +16,18 @@ let
     adminvm = "192.168.101.10";
     appvm = "192.168.101.100";
   };
-  admin = {
+  adminConfig = {
     name = "admin-vm";
-    addr = addrs.adminvm;
-    port = "9001";
-    protocol = "tcp";
+    addresses = [
+      {
+        name = "admin-vm";
+        addr = addrs.adminvm;
+        port = "9001";
+        protocol = "tcp";
+      }
+    ];
   };
+  admin = lib.head adminConfig.addresses;
   mkTls = name: {
     enable = tls;
     caCertPath = "${snakeoil}/${name}/ca-cert.pem";
@@ -48,10 +54,8 @@ in
               environment.systemPackages = [ pkgs.grpcurl ];
               givc.admin = {
                 enable = true;
-                inherit (admin) name;
-                inherit (admin) addr;
-                inherit (admin) port;
-                inherit (admin) protocol;
+                inherit (adminConfig) name;
+                inherit (adminConfig) addresses;
                 tls = mkTls "admin-vm";
                 debug = false;
               };

--- a/nixos/tests/netvm.nix
+++ b/nixos/tests/netvm.nix
@@ -13,12 +13,18 @@ let
     netvm = "192.168.101.1";
     adminvm = "192.168.101.2";
   };
-  admin = {
+  adminConfig = {
     name = "admin-vm";
-    addr = addrs.adminvm;
-    port = "9001";
-    protocol = "tcp"; # go version expect word "tcp" here, but it unused
+    addresses = [
+      {
+        name = "admin-vm";
+        addr = addrs.adminvm;
+        port = "9001";
+        protocol = "tcp";
+      }
+    ];
   };
+  admin = lib.head adminConfig.addresses;
   mkTls = name: {
     enable = tls;
     caCertPath = "${snakeoil}/${name}/ca-cert.pem";
@@ -45,10 +51,8 @@ in
               environment.systemPackages = [ pkgs.grpcurl ];
               givc.admin = {
                 enable = true;
-                inherit (admin) name;
-                inherit (admin) addr;
-                inherit (admin) port;
-                inherit (admin) protocol;
+                inherit (adminConfig) name;
+                inherit (adminConfig) addresses;
                 tls = mkTls "admin-vm";
               };
             };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

`THIS CHANGE BREAKS GHAF - DO NOT BUMP WITHOUT PR`

Adding multiple transport configs to the admin nixos module.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Test procedure added to nixos/tests
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
