### PR TITLE
fix(firewall): fix tcp rules

### DIFF
--- a/nixos/modules/admin.nix
+++ b/nixos/modules/admin.nix
@@ -25,6 +25,9 @@ let
     transportSubmodule
     tlsSubmodule
     ;
+  tcpAddresses = lib.filter (addr: addr.protocol == "tcp") cfg.addresses;
+  unixAddresses = lib.filter (addr: addr.protocol == "unix") cfg.addresses;
+  vsockAddresses = lib.filter (addr: addr.protocol == "vsock") cfg.addresses;
 in
 {
   options.givc.admin = {
@@ -74,9 +77,6 @@ in
 
     systemd.services.givc-admin =
       let
-        tcpAddresses = lib.filter (addr: addr.protocol == "tcp") cfg.addresses;
-        unixAddresses = lib.filter (addr: addr.protocol == "unix") cfg.addresses;
-        vsockAddresses = lib.filter (addr: addr.protocol == "vsock") cfg.addresses;
         args = concatStringsSep " " (
           (map (addr: "--listen-tcp ${addr.addr}:${addr.port}") tcpAddresses)
           ++ (map (addr: "--listen-unix ${addr.addr}") unixAddresses)
@@ -113,6 +113,6 @@ in
             "GIVC_LOG" = "debug";
           };
       };
-    networking.firewall.allowedTCPPorts = unique (map (addr: strings.toInt addr.port) cfg.addresses);
+    networking.firewall.allowedTCPPorts = unique (map (addr: strings.toInt addr.port) tcpAddresses);
   };
 }


### PR DESCRIPTION
Add only tcp ports to firewall rules.

<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

Only use tcp ports for firewall rules. 

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [x] Author has run `nix flake check` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
