### PR TITLE
Split VM services

### DIFF
--- a/modules/pkgs/servicemanager/controller.go
+++ b/modules/pkgs/servicemanager/controller.go
@@ -88,7 +88,7 @@ func (c *SystemdController) IsUnitWhitelisted(name string) bool {
 		}
 		// Application instances are whitelisted based
 		// on their base name, so we match with regex
-		re := regexp.MustCompile(`^` + val + `@[0-9]+\.service$`)
+		re := regexp.MustCompile(`^\Q` + val + `\E@[0-9]+\.service$`)
 		if re.MatchString(name) {
 			return true
 		}

--- a/nixos/modules/host.nix
+++ b/nixos/modules/host.nix
@@ -50,6 +50,26 @@ in
       example = "[ 'my-service.service' ]";
     };
 
+    systemVms = mkOption {
+      description = ''
+        List of systemd VM services for the manager to administrate. Expects a space separated list.
+        Should be a unit file of type 'service' or 'target'.
+      '';
+      type = types.listOf types.str;
+      default = [ ];
+      example = "[ 'microvm@net-vm.service' ]";
+    };
+
+    appVms = mkOption {
+      description = ''
+        List of systemd VM services for the manager to administrate. Expects a space separated list.
+        Should be a unit file of type 'service' or 'target'.
+      '';
+      type = types.listOf types.str;
+      default = [ ];
+      example = "[ 'microvm@chrome-vm.service' ]";
+    };
+
     admin = mkOption {
       description = "Admin server configuration.";
       type = transportSubmodule;
@@ -95,6 +115,8 @@ in
         "TYPE" = "0";
         "SUBTYPE" = "1";
         "SERVICES" = "${concatStringsSep " " cfg.services}";
+        "SYSVMS" = "${concatStringsSep " " cfg.systemVms}";
+        "APPVMS" = "${concatStringsSep " " cfg.appVms}";
         "ADMIN_SERVER" = "${toJSON cfg.admin}";
         "TLS_CONFIG" = "${toJSON cfg.tls}";
       };

--- a/nixos/tests/admin.nix
+++ b/nixos/tests/admin.nix
@@ -88,11 +88,13 @@ in
                 };
                 admin = lib.head adminConfig.addresses;
                 services = [
-                  "microvm@app-vm.service"
                   "poweroff.target"
                   "reboot.target"
                   "sleep.target"
                   "suspend.target"
+                ];
+                appVms = [
+                  "microvm@app-vm.service"
                 ];
                 tls.enable = tls;
               };
@@ -343,7 +345,8 @@ in
 
                   time.sleep(1)
                   # Ensure, that hostvm's agent registered in admin service. It take ~10 seconds to spin up and register itself
-                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 ${expected}"))
+                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 0 ${expected}"))
+                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 microvm@app-vm.service"))
 
               with subtest("setup gui vm"):
                   # Ensure that sway in guiVM finished startup


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

Split VMs from other services so they are registered using correct type.

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [X] Summary of the proposed changes in the PR description
- [X] Test procedure added to nixos/tests
- [X] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [X] Author has added reviewers and removed PR draft status

## Testing

Verify that VMs are listed in ctrl-panel. Alternatively use givc-cli watch --initial and verify VMs are listed with correct type.
<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
