### PR TITLE
Add name data for virtual machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,2 @@
 [workspace]
-members = [
-  "crates/client",
-  "crates/common",
-  "crates/admin"
-]
+members = ["crates/client", "crates/common", "crates/admin"]

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -8,29 +8,42 @@ version = "0.0.1"
 
 [dependencies]
 anyhow = "1.0.86"
-async-stream = "0.3"
 async-channel = "2.3.1"
-strum = {version = "0.26", features = ["derive"]}
-clap = {version = "4.5.4", features = ["derive", "env"]}
+async-stream = "0.3"
+clap = { version = "4.5.4", features = ["derive", "env"] }
 console = "0.15"
 prost = "0.13"
 regex = "1.11"
-tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros", "fs"]}
-tokio-stream = "0.1"
-tokio-vsock = "0.5"
-tonic = {version="0.12", features = ["tls"]}
-tonic-types = {version="0.12"}
-tonic-reflection = {version="0.12"}
-tower = {version = "0.4"}
-tracing = "0.1"
-tracing-subscriber = {version = "0.3", features = ["env-filter", "tracing-log", "time", "local-time"]}
-tracing-journald = {version =" 0.2.0"}
-serde = { version = "1.0.202", features = ["derive"]}
 serde_json = "1.0.120"
-x509-parser = { version = "0.16" }
-
-tokio-listener = { features = ["multi-listener", "tonic012", "vsock"], git = "https://github.com/avnik/tokio-listener", branch = "avnik/vsock-ghaf" }
+serde = { version = "1.0.202", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
+tokio-stream = "0.1"
+tokio = { version = "1.0", features = [
+  "rt-multi-thread",
+  "time",
+  "macros",
+  "fs",
+] }
+tokio-vsock = "0.5"
+tonic-reflection = "0.12"
+tonic-types = "0.12"
+tonic = { version = "0.12", features = ["tls"] }
+tower = "0.4"
+tracing = "0.1"
+tracing-journald = "0.2.0"
+tracing-subscriber = { version = "0.3", features = [
+  "env-filter",
+  "tracing-log",
+  "time",
+  "local-time",
+] }
+x509-parser = "0.16"
 
 # GIVC subparts
-givc-common = { path="../common" } 
-givc-client = { path="../client" } 
+givc-common = { path = "../common" }
+givc-client = { path = "../client" }
+
+[dependencies.tokio-listener]
+features = ["multi-listener", "tonic012", "vsock"]
+git = "https://github.com/avnik/tokio-listener"
+branch = "avnik/vsock-ghaf"

--- a/crates/admin/src/admin/entry.rs
+++ b/crates/admin/src/admin/entry.rs
@@ -38,10 +38,14 @@ impl RegistryEntry {
     }
 
     pub fn vm_name(&self) -> Option<&str> {
-        match &self.placement {
-            Placement::Endpoint { vm, .. } => Some(vm),
-            Placement::Managed { vm, .. } => Some(vm),
-            Placement::Host => None,
+        match (self.r#type.service, &self.placement) {
+            (ServiceType::VM, _) => self
+                .name
+                .strip_prefix("microvm@")
+                .and_then(|name| name.strip_suffix(".service")),
+            (_, Placement::Endpoint { ref vm, .. }) => Some(vm),
+            (_, Placement::Managed { ref vm, .. }) => Some(vm),
+            (_, Placement::Host) => None,
         }
     }
 

--- a/crates/admin/src/bin/givc-cli.rs
+++ b/crates/admin/src/bin/givc-cli.rs
@@ -130,6 +130,8 @@ enum Test {
         service: String,
         #[arg(long, value_parser=unit_type_parse)]
         r#type: Option<UnitType>,
+        #[arg(long)]
+        vm: Option<String>,
     },
 }
 
@@ -138,6 +140,7 @@ async fn test_subcommands(test: Test, admin: AdminClient) -> anyhow::Result<()> 
         service,
         retry,
         r#type,
+        vm,
     } = test;
 
     let mut ival = interval(time::Duration::from_secs(1));
@@ -149,10 +152,12 @@ async fn test_subcommands(test: Test, admin: AdminClient) -> anyhow::Result<()> 
             .into_iter()
             .find(|r| r.name == service)
         {
-            if !r#type.is_some_and(|t| t.vm != r.vm_type || t.service != r.service_type) {
-                return Ok(());
-            } else {
+            if r#type.is_some_and(|t| t.vm != r.vm_type || t.service != r.service_type) {
                 anyhow::bail!("test failed '{service}' registered but of wrong type");
+            } else if vm.is_some() && vm != r.vm_name {
+                anyhow::bail!("test failed '{service}' registered but on wrong VM");
+            } else {
+                return Ok(());
             }
         }
     }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -10,14 +10,14 @@ version = "0.0.1"
 anyhow = "1.0.86"
 async-channel = "2.3.1"
 async-stream = "0.3"
-hyper-util = { version = "0.1"}
-tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros"]}
+hyper-util = "0.1"
+serde = { version = "1.0.202", features = ["derive"] }
 tokio-stream = "0.1"
+tokio = { version = "1.0", features = ["rt-multi-thread", "time", "macros"] }
 tokio-vsock = "*"
-tonic = {version="0.12", features = ["tls"]}
-tonic-types = {version="0.12"}
-tower = {version = "0.4"}
+tonic-types = "0.12"
+tonic = { version = "0.12", features = ["tls"] }
+tower = "0.4"
 tracing = "0.1"
-serde = { version = "1.0.202", features = ["derive"]}
 
 givc-common = { path = "../common" }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -10,15 +10,15 @@ version = "0.0.1"
 anyhow = "1.0.86"
 async-stream = "0.3"
 prost = "0.13"
-tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros"]}
-tokio-stream = "0.1"
-tokio-vsock = "*"
-tonic = {version="0.12", features = ["tls"]}
-tonic-types = {version="0.12"}
-tracing = "0.1"
-tracing-subscriber = {version = "0.3"}
-serde = { version = "1.0.202", features = ["derive"]}
+serde = { version = "1.0.202", features = ["derive"] }
 strum = { version = "0.26", features = ["derive"] }
+tokio-stream = "0.1"
+tokio = { version = "1.0", features = ["rt-multi-thread", "time", "macros"] }
+tokio-vsock = "*"
+tonic-types = "0.12"
+tonic = { version = "0.12", features = ["tls"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [build-dependencies]
-tonic-build = {version = "0.12", features = ["prost"]}
+tonic-build = { version = "0.12", features = ["prost"] }

--- a/nixos/checks/treefmt.nix
+++ b/nixos/checks/treefmt.nix
@@ -26,6 +26,7 @@
           statix.enable = true; # prevents use of nix anti-patterns https://github.com/nerdypepper/statix
           gofmt.enable = true; # go formatter https://golang.org/cmd/gofmt/
           shellcheck.enable = true; # lints shell scripts https://github.com/koalaman/shellcheck
+          taplo.enable = true;
         };
       };
 

--- a/nixos/tests/admin.nix
+++ b/nixos/tests/admin.nix
@@ -346,7 +346,7 @@ in
                   time.sleep(1)
                   # Ensure, that hostvm's agent registered in admin service. It take ~10 seconds to spin up and register itself
                   print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 0 ${expected}"))
-                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 microvm@app-vm.service"))
+                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 --vm app-vm microvm@app-vm.service"))
 
               with subtest("setup gui vm"):
                   # Ensure that sway in guiVM finished startup


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

Implement vm_name() for RegistryEntries of type VM to return the name of the VM.

Also add treefmt formatter for toml files.

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [X] Summary of the proposed changes in the PR description
- [X] Test procedure added to nixos/tests
- [X] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [X] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
