### PR TITLE
fix(hwid): fix hwid reporting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1739053031,
-        "narHash": "sha256-LrMDRuwAlRFD2T4MgBSRd1s2VtOE+Vl1oMCNu3RpPE0=",
+        "lastModified": 1741396358,
+        "narHash": "sha256-js4c6tqxluo4Fysn8gloLnlZ6ZjQkuWMgGjHN8+WssE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "112e6591b2d6313b1bd05a80a754a8ee42432a7e",
+        "rev": "aaebfb7ce7e13c691aea178aff7621906f466662",
         "type": "github"
       },
       "original": {

--- a/modules/pkgs/hwidmanager/transport.go
+++ b/modules/pkgs/hwidmanager/transport.go
@@ -45,8 +45,8 @@ func (s *HwIdServer) GetHwId(ctx context.Context, req *hwid.HwIdRequest) (*hwid.
 
 	identifier, err := s.Controller.GetIdentifier(context.Background())
 	if err != nil {
-		log.Infof("[GetHwId] Error getting hardware identifier: %v\n", err)
-		return nil, fmt.Errorf("cannot get hardware id")
+		log.Infof("[GetHwId] Error getting hardware identifier: %v", err)
+		return nil, fmt.Errorf("cannot get hardware id: %v", err)
 	}
 
 	return &hwid.HwIdResponse{Identifier: identifier}, nil

--- a/nixos/modules/sysvm.nix
+++ b/nixos/modules/sysvm.nix
@@ -131,9 +131,9 @@ in
     systemd.targets.givc-setup = {
       enable = true;
       description = "Ghaf givc target";
-      bindsTo = [ "network.target" ];
+      requires = [ "network.target" ];
       after = [ "network.target" ];
-      wantedBy = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
     };
 
     systemd.services.givc-user-key-setup = optionalAttrs cfg.enableUserTlsAccess {


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
## Description

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

As the interface is brought up, it will report a random MAC address. This can cause issues with external queries, depending on the timing. Checking device "up" still leaves a chance of a wrong MAC.

Checking `/sys/class/net/<iface>/carrier` also appears to work, but for simplicity we are using go's net lib to query if the device is running.

Additional fixes:
- add ethernet interface as automatic alternative (untested atm)
- bump crane to remove warnings

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [ ] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
Tested to work on Ghaf.