### PR TITLE
fix(nixos): fix dbus imports

### DIFF
--- a/nixos/modules/appvm.nix
+++ b/nixos/modules/appvm.nix
@@ -86,8 +86,6 @@ in
     };
   };
 
-  imports = [ self.nixosModules.dbus ];
-
   config = mkIf cfg.enable {
     assertions = [
       {

--- a/nixos/modules/sysvm.nix
+++ b/nixos/modules/sysvm.nix
@@ -99,8 +99,6 @@ in
     };
   };
 
-  imports = [ self.nixosModules.dbus ];
-
   config = mkIf cfg.enable {
 
     assertions = [

--- a/nixos/tests/dbus.nix
+++ b/nixos/tests/dbus.nix
@@ -73,6 +73,7 @@ in
             {
               imports = [
                 self.nixosModules.sysvm
+                self.nixosModules.dbus
                 ./snakeoil/gen-test-certs.nix
               ];
 
@@ -195,6 +196,7 @@ in
             {
               imports = [
                 self.nixosModules.sysvm
+                self.nixosModules.dbus
                 ./snakeoil/gen-test-certs.nix
               ];
 
@@ -279,6 +281,7 @@ in
             {
               imports = [
                 self.nixosModules.sysvm
+                self.nixosModules.dbus
                 ./snakeoil/gen-test-certs.nix
               ];
 
@@ -375,6 +378,7 @@ in
             {
               imports = [
                 self.nixosModules.appvm
+                self.nixosModules.dbus
                 ./snakeoil/gen-test-certs.nix
               ];
 


### PR DESCRIPTION


<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Remove internal dbus proxy import to flatten exported namespace.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [ ] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
