### PR TITLE
fix(check-cert): Added certificate checker

### DIFF
--- a/nixos/modules/host.nix
+++ b/nixos/modules/host.nix
@@ -100,8 +100,14 @@ in
     systemd.services."givc-${cfg.transport.name}" = {
       description = "GIVC remote service manager for the host.";
       enable = true;
-      after = [ "network.target" ];
-      wants = [ "network.target" ];
+      after = [
+        "givc-key-setup.service"
+        "network.target"
+      ];
+      wants = [
+        "givc-key-setup.service"
+        "network.target"
+      ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "exec";

--- a/nixos/modules/tls.nix
+++ b/nixos/modules/tls.nix
@@ -92,7 +92,7 @@ in
           description = "Generate keys and certificates for givc";
           path = [ givcCertGenerator ];
           wantedBy = [ "local-fs.target" ];
-          after = [ "local-fs.target" ];
+          after = [ "givc-check-certs.service" ];
           unitConfig.ConditionPathExists = "!/etc/givc/tls.lock";
           serviceConfig = {
             Type = "notify";
@@ -101,6 +101,29 @@ in
             StandardOutput = "journal";
             StandardError = "journal";
             ExecStart = "${givcCertGenerator}/bin/givc-gen-certs ${cfg.storagePath}";
+          };
+        };
+      givc-check-certs =
+        let
+          givcCertChecker = pkgs.callPackage ../packages/givc-check-certs.nix {
+            inherit lib pkgs;
+            inherit (cfg)
+              agents
+              ;
+          };
+        in
+        {
+          enable = true;
+          description = "Check certificates for givc";
+          path = [ givcCertChecker ];
+          wantedBy = [ "local-fs.target" ];
+          after = [ "local-fs.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            Restart = "no";
+            StandardOutput = "journal";
+            StandardError = "journal";
+            ExecStart = "${givcCertChecker}/bin/givc-check-certs";
           };
         };
     };

--- a/nixos/packages/givc-check-certs.nix
+++ b/nixos/packages/givc-check-certs.nix
@@ -1,0 +1,32 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  pkgs,
+  agents,
+}:
+pkgs.writeShellScriptBin "givc-check-certs" ''
+  set -xeuo pipefail
+
+  CERTS_FILE="/etc/givc/givc.certs"
+
+  # Function to compare vm certificates
+  compare_cert(){
+
+      # Initialize name
+      name="$1"
+
+      # Certificate not generated before, cleanup & regenerate the certs file
+      if [[ ! "$existing_certs" =~ "$name" ]]; then
+          rm $CERTS_FILE
+          rm /etc/givc/tls.lock
+          exit 0
+      fi
+  }
+
+  # Check if certs file exist
+  if [ -f $CERTS_FILE ]; then
+    existing_certs=$(<$CERTS_FILE)
+    ${lib.concatStringsSep "\n" (map (entry: "compare_cert ${entry.name} $existing_certs") agents)}
+  fi
+''

--- a/nixos/packages/givc-gen-certs.nix
+++ b/nixos/packages/givc-gen-certs.nix
@@ -32,6 +32,7 @@ pkgs.writeShellScriptBin "givc-gen-certs" ''
 
       # Initialize name and storage path
       name="$1"
+      printf "$name " >> /tmp/givc.certs
       path="/tmp/givc.tmp"
       [[ -d "$path" ]] && rm -r "$path"
       mkdir -p "$path"
@@ -107,6 +108,9 @@ pkgs.writeShellScriptBin "givc-gen-certs" ''
 
   # Create lock file
   ${pkgs.coreutils}/bin/install -m 000 /dev/null /etc/givc/tls.lock
+
+  # Move the generated certs file
+  mv /tmp/givc.certs /etc/givc
 
   /run/current-system/systemd/bin/systemd-notify --ready
 ''


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description
Created systemd service which is responsible for checking if certificate is already generated for
the particular agent, if not it will invoke certificate generator service.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [x] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing
1. Tested on Lenovo Gen 11, by enabling/disabling few `app-vms`  listed [here](https://github.com/tiiuae/ghaf/blob/main/modules/reference/profiles/mvp-user-trial.nix#L42)
2. On first boot, certificates will be generated, if any vm/agent enabled later on then certificates will be generated again. 

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
