### PR TITLE
Enable policy server in admin vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,11 +150,11 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -105,7 +165,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
  "synstructure",
 ]
 
@@ -117,7 +177,18 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -130,6 +201,146 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-dup"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2886ab563af5038f79ec016dd7b87947ed138b794e8dd64992962c9cca0411"
+dependencies = [
+ "async-lock 3.4.0",
+ "futures-io",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.1.1",
+ "futures-lite 2.6.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "blocking",
+ "futures-lite 2.6.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-h1"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d1dae8cb2c4258a79d6ed088b7fb9b4763bf4e9b22d040779761e046a2971"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-dup",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "futures-lite 1.13.0",
+ "http-types",
+ "httparse",
+ "log",
+ "pin-project",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.28",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock 3.4.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "parking",
+ "polling 3.7.4",
+ "rustix 0.38.37",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -151,7 +362,26 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-tls"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85a97c4a0ecce878efd3f945f119c78a646d8975340bca0398f9bb05c30cc52"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "rustls 0.18.1",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -162,7 +392,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -236,8 +466,26 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -256,6 +504,34 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -283,6 +559,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "clap"
@@ -315,7 +600,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -340,6 +625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.3",
+ "serde",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,16 +649,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+
+[[package]]
+name = "cookie"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+dependencies = [
+ "aes-gcm",
+ "base64 0.13.1",
+ "hkdf",
+ "hmac",
+ "percent-encoding",
+ "rand 0.8.5",
+ "sha2",
+ "time 0.2.27",
+ "version_check",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deadpool"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
+dependencies = [
+ "async-trait",
+ "config",
+ "crossbeam-queue",
+ "num_cpus",
+ "serde",
+ "tokio",
+]
 
 [[package]]
 name = "der-parser"
@@ -372,7 +761,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -388,6 +777,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,7 +799,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -437,6 +841,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -452,8 +862,17 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener",
+ "event-listener 5.3.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -473,6 +892,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -523,6 +951,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand 2.1.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,7 +986,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -564,6 +1020,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +1048,17 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -585,7 +1072,7 @@ name = "givc"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-channel 2.3.1",
  "async-stream",
  "clap",
  "console",
@@ -596,6 +1083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "surf",
  "tokio",
  "tokio-listener",
  "tokio-stream",
@@ -615,7 +1103,7 @@ name = "givc-client"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-channel 2.3.1",
  "async-stream",
  "givc-common",
  "hyper-util",
@@ -646,6 +1134,18 @@ dependencies = [
  "tonic-types",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -692,6 +1192,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +1249,47 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-client"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
+dependencies = [
+ "async-h1",
+ "async-std",
+ "async-tls",
+ "async-trait",
+ "cfg-if",
+ "dashmap",
+ "deadpool",
+ "futures",
+ "http-types",
+ "log",
+ "rustls 0.18.1",
+]
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel 1.9.0",
+ "async-std",
+ "base64 0.13.1",
+ "cookie",
+ "futures-lite 1.13.0",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -784,11 +1351,150 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -809,6 +1515,32 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -833,10 +1565,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -846,9 +1610,21 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
@@ -857,10 +1633,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "matchers"
@@ -899,6 +1688,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,9 +1718,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -952,6 +1751,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1009,6 +1819,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1878,19 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1086,7 +1925,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1100,6 +1939,59 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.1.1",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix 0.38.37",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1123,8 +2015,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.77",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -1162,7 +2060,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.77",
  "tempfile",
 ]
 
@@ -1176,7 +2074,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1199,13 +2097,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1215,7 +2136,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1224,7 +2154,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1273,16 +2221,31 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
- "untrusted",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1293,12 +2256,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1310,8 +2296,21 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+dependencies = [
+ "base64 0.12.3",
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1322,7 +2321,7 @@ checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "log",
  "once_cell",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1335,7 +2334,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -1351,9 +2350,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1367,6 +2366,37 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1385,7 +2415,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1398,6 +2428,57 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1432,6 +2513,16 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -1442,9 +2533,85 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -1471,7 +2638,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1479,6 +2646,39 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "surf"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "cfg-if",
+ "futures-util",
+ "getrandom 0.2.15",
+ "http-client",
+ "http-types",
+ "log",
+ "mime_guess",
+ "once_cell",
+ "pin-project-lite",
+ "rustls 0.18.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1511,7 +2711,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1521,9 +2721,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.1.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.37",
  "windows-sys 0.59.0",
 ]
 
@@ -1544,7 +2744,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1555,6 +2755,21 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros 0.1.1",
+ "version_check",
+ "winapi",
 ]
 
 [[package]]
@@ -1571,7 +2786,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
+ "time-macros 0.2.18",
 ]
 
 [[package]]
@@ -1582,12 +2797,45 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1601,7 +2849,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1616,7 +2864,7 @@ dependencies = [
  "futures-util",
  "nix 0.26.4",
  "pin-project",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-util",
  "tokio-vsock",
@@ -1632,7 +2880,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1641,7 +2889,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]
@@ -1692,7 +2940,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -1705,7 +2953,7 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-pemfile",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -1726,7 +2974,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1764,7 +3012,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1805,7 +3053,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1853,7 +3101,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time",
+ "time 0.3.36",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -1864,6 +3112,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -1878,10 +3138,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1896,6 +3196,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "vsock"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +3216,12 @@ dependencies = [
  "libc",
  "nix 0.27.1",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "want"
@@ -1916,9 +3234,115 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"
@@ -1944,11 +3368,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1957,7 +3390,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1966,15 +3414,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1984,9 +3438,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2002,9 +3468,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2014,15 +3492,39 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "x509-parser"
@@ -2034,11 +3536,35 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.36",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "synstructure",
 ]
 
 [[package]]
@@ -2059,7 +3585,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "synstructure",
 ]
 
 [[package]]
@@ -2067,3 +3614,25 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]

--- a/api/admin/admin.proto
+++ b/api/admin/admin.proto
@@ -89,6 +89,15 @@ message TimezoneRequest {
     string Timezone = 1;
 }
 
+message PolicyQueryRequest {
+    string PolicyPath = 1;
+    string Query = 2;
+}
+
+message PolicyQueryResponse {
+    string result = 1;
+}
+
 service AdminService {
     rpc RegisterService(RegistryRequest) returns (RegistryResponse) {}
 
@@ -114,4 +123,6 @@ service AdminService {
     // Query
     rpc QueryList(Empty) returns (QueryListResponse) {}
     rpc Watch(Empty) returns (stream WatchItem) {}
+
+    rpc PolicyQuery(PolicyQueryRequest) returns (PolicyQueryResponse) {}
 }

--- a/api/admin/admin.proto
+++ b/api/admin/admin.proto
@@ -90,8 +90,8 @@ message TimezoneRequest {
 }
 
 message PolicyQueryRequest {
-    string PolicyPath = 1;
-    string Query = 2;
+    string Query = 1;
+    string PolicyPath = 2;
 }
 
 message PolicyQueryResponse {

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -14,6 +14,9 @@ clap = { version = "4.5.4", features = ["derive", "env"] }
 console = "0.15"
 prost = "0.13"
 regex = "1.11"
+surf = { version = "2.3.2", default-features = false, features = [
+  "h1-client-rustls",
+] }
 serde_json = "1.0.120"
 serde = { version = "1.0.202", features = ["derive"] }
 strum = { version = "0.26", features = ["derive"] }

--- a/crates/admin/src/admin/mod.rs
+++ b/crates/admin/src/admin/mod.rs
@@ -1,3 +1,4 @@
 pub mod entry;
+pub mod policy_server;
 pub mod registry;
 pub mod server;

--- a/crates/admin/src/admin/policy_server.rs
+++ b/crates/admin/src/admin/policy_server.rs
@@ -1,0 +1,95 @@
+//use anyhow::{anyhow, bail, Context, Result};
+//use serde_json::json;
+use anyhow::anyhow;
+use serde_json::Value;
+use tracing::info;
+use tracing::{debug, error};
+
+#[derive(Debug)]
+
+pub struct PolicyServer {
+    url: String,
+}
+
+impl PolicyServer {
+    pub fn new(serverurl: String) -> Self {
+        debug!(
+            "Creating Interface to Policy Server with URL: {}",
+            serverurl
+        );
+        Self { url: serverurl }
+    }
+
+    pub async fn request(&self, query: &str, policy_path: &str) -> anyhow::Result<String> {
+        let opa_url = format!("{}{}", self.url, policy_path);
+        info!("Policy QUERY: {:#?}, URL: {:#?} ", query, opa_url);
+
+        let body = surf::Body::from_string((&query).to_string());
+
+        let request = surf::post(opa_url).body(body);
+        let mut res = match request.await {
+            Ok(response) => response,
+            Err(e) => {
+                error!("Failed to send request to OPA server: {}", e);
+                return Ok("{}".to_string());
+            }
+        };
+
+        let body_string = match res.body_string().await {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Failed to read body string: {}", e);
+                return Ok("{}".to_string());
+            }
+        };
+        Ok(body_string)
+    }
+
+    pub async fn evaluate_query(&self, query: &str, policy_path: &str) -> anyhow::Result<String> {
+        if let Some(json_payload) = query.strip_prefix("json:") {
+            debug!("Detected 'json:' prefix.");
+            let result = self.request(json_payload, policy_path).await?;
+            Ok(result)
+        } else if let Some(command_line) = query.strip_prefix("cmd:") {
+            debug!("Detected 'cmd:' prefix.");
+            let result = self.handle_cmds(command_line).await?;
+            Ok(result)
+        } else {
+            Err(anyhow!(
+                "Unrecognized query prefix. Expected 'json:' or 'cmd:'"
+            ))
+        }
+    }
+
+    pub async fn split_cmd_and_args<'a>(&self, cmdstr: &'a str) -> Option<(&'a str, &'a str)> {
+        let mut parts = cmdstr.trim().splitn(2, ' ');
+        let cmd = parts.next()?;
+        let args = parts.next().unwrap_or("");
+        Some((cmd, args))
+    }
+
+    pub async fn handle_cmds(&self, cmdstr: &str) -> anyhow::Result<String> {
+        if let Some((cmd, args)) = self.split_cmd_and_args(cmdstr).await {
+            info!("First word: {}", cmd);
+            info!("Remaining: {}", args);
+            match cmd {
+                "fetch" => self.run_fetch_rules(args).await,
+                // Add other commands here
+                _ => Err(anyhow!("Unknown command: {}", cmd)),
+            }
+        } else {
+            error!("Invalid command! {}", cmdstr);
+            Err(anyhow!("Invalid command {}", cmdstr))
+        }
+    }
+
+    // --- Command Handlers ---
+
+    async fn run_fetch_rules(&self, args: &str) -> anyhow::Result<String> {
+        let rule_path = args.trim();
+        let json_string = format!(r#"{{"input":{{}}}}"#,);
+
+        let result = self.request(json_string.as_str(), rule_path).await?;
+        Ok(result)
+    }
+}

--- a/crates/admin/src/bin/givc-cli.rs
+++ b/crates/admin/src/bin/givc-cli.rs
@@ -117,8 +117,9 @@ enum Commands {
         test: Test,
     },
     PolicyQuery {
-        policy_path: String,
         query: String,
+        #[arg(default_value = "")]
+        policy_path: String,
     },
 }
 
@@ -263,14 +264,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 dump(watch.channel.recv().await?, as_json)?;
             }
         }
-        Commands::PolicyQuery { policy_path, query } => {
-            let response = admin.policy_query(policy_path, query).await?;
-            println!("{:?}", response)
+        Commands::PolicyQuery { query, policy_path } => {
+            let response = admin.policy_query(query, policy_path).await?;
+            println!("{:#?}", response.result)
         }
     };
 
     Ok(())
 }
+
 
 fn dump<Q>(qr: Q, as_json: bool) -> anyhow::Result<()>
 where

--- a/crates/admin/src/bin/givc-cli.rs
+++ b/crates/admin/src/bin/givc-cli.rs
@@ -116,6 +116,10 @@ enum Commands {
         #[command(subcommand)]
         test: Test,
     },
+    PolicyQuery {
+        policy_path: String,
+        query: String,
+    },
 }
 
 fn unit_type_parse(s: &str) -> anyhow::Result<UnitType> {
@@ -258,6 +262,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             while !limit.as_mut().is_some_and(|l| l.next().is_none()) {
                 dump(watch.channel.recv().await?, as_json)?;
             }
+        }
+        Commands::PolicyQuery { policy_path, query } => {
+            let response = admin.policy_query(policy_path, query).await?;
+            println!("{:?}", response)
         }
     };
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -274,10 +274,10 @@ impl AdminClient {
 
     pub async fn policy_query(
         &self,
-        policy_path: String,
         query: String,
+        policy_path: String,
     ) -> anyhow::Result<pb::admin::PolicyQueryResponse> {
-        let request = pb::admin::PolicyQueryRequest { policy_path, query };
+        let request = pb::admin::PolicyQueryRequest { query, policy_path };
         let response = self
             .connect_to()
             .await?

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -272,6 +272,21 @@ impl AdminClient {
             .rewrap_err()
     }
 
+    pub async fn policy_query(
+        &self,
+        policy_path: String,
+        query: String,
+    ) -> anyhow::Result<pb::admin::PolicyQueryResponse> {
+        let request = pb::admin::PolicyQueryRequest { policy_path, query };
+        let response = self
+            .connect_to()
+            .await?
+            .policy_query(request)
+            .await
+            .rewrap_err()?;
+        Ok(response.into_inner())
+    }
+
     pub async fn watch(&self) -> anyhow::Result<WatchResult> {
         use pb::admin::watch_item::Status;
         use pb::admin::WatchItem;

--- a/nixos/tests/admin.nix
+++ b/nixos/tests/admin.nix
@@ -56,426 +56,374 @@ in
   perSystem =
     { self', ... }:
     {
-      vmTests.tests.admin =
-        let
-          policyPath = "/etc/opa/policies";
-        in
-        {
-          module = {
-            nodes = {
-              adminvm = {
-                imports = [
-                  self.nixosModules.admin
-                  ./snakeoil/gen-test-certs.nix
-                ];
+      vmTests.tests.admin = {
+        module = {
+          nodes = {
+            adminvm = {
+              imports = [
+                self.nixosModules.admin
+                ./snakeoil/gen-test-certs.nix
+              ];
 
-                # TLS parameter
-                givc-tls-test = {
-                  inherit (admin) name;
-                  addresses = admin.addr;
-                };
-
-                networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-                  {
-                    address = addrs.adminvm;
-                    prefixLength = 24;
-                  }
-                ];
-
-                givc.admin = {
-                  enable = true;
-                  debug = true;
-                  inherit (adminConfig) name;
-                  inherit (adminConfig) addresses;
-                  tls.enable = tls;
-                  opa = {
-                    enable = true;
-                    policies = policyPath;
-                  };
-                };
-                environment.etc."opa/policies/usb-access.rego".text = opaUSBPolicy;
+              # TLS parameter
+              givc-tls-test = {
+                inherit (admin) name;
+                addresses = admin.addr;
               };
-              hostvm = {
+
+              networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+                {
+                  address = addrs.adminvm;
+                  prefixLength = 24;
+                }
+              ];
+
+              givc.admin = {
+                enable = true;
+                debug = true;
+                inherit (adminConfig) name;
+                inherit (adminConfig) addresses;
+                tls.enable = tls;
+                opa = {
+                  enable = true;
+                  policies = {
+                    url = "https://github.com/gngram/ghaf-rego-policies/archive/refs/heads/main.tar.gz";
+                    sha256 = "sha256-+c0KDyEG+kRyeLN7FSScCnY3U53rcxVw06Vm6Z6kxBw=";
+                    #sha256 = "sha256-DiNnxp3WSmmzjnfDRUaS99gsmOKycfM6F82a/9HDutc=";
+                  };
+                };
+              };
+              environment.etc."opa/policies/usb-access.rego".text = opaUSBPolicy;
+            };
+            hostvm = {
+              imports = [
+                self.nixosModules.host
+                ./snakeoil/gen-test-certs.nix
+              ];
+
+              # TLS parameter
+              givc-tls-test = {
+                name = "ghaf-host";
+                addresses = addrs.host;
+              };
+
+              networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+                {
+                  address = addrs.host;
+                  prefixLength = 24;
+                }
+              ];
+              givc.host = {
+                enable = true;
+                transport = {
+                  name = "ghaf-host";
+                  addr = addrs.host;
+                  port = "9000";
+                  protocol = "tcp";
+                };
+                admin = lib.head adminConfig.addresses;
+                services = [
+                  "poweroff.target"
+                  "reboot.target"
+                  "sleep.target"
+                  "suspend.target"
+                ];
+                appVms = [
+                  "microvm@app-vm.service"
+                ];
+                tls.enable = tls;
+              };
+              systemd.services."microvm@app-vm" = {
+                script = ''
+                  # Do nothing script, simulating microvm service
+                  while true; do sleep 10; done
+                '';
+              };
+            };
+            guivm =
+              { pkgs, ... }:
+              let
+                inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs)
+                  snakeOilPrivateKey
+                  snakeOilPublicKey
+                  ;
+              in
+              {
                 imports = [
-                  self.nixosModules.host
+                  self.nixosModules.sysvm
                   ./snakeoil/gen-test-certs.nix
                 ];
 
                 # TLS parameter
                 givc-tls-test = {
-                  name = "ghaf-host";
-                  addresses = addrs.host;
+                  name = "gui-vm";
+                  addresses = addrs.guivm;
                 };
+                # Setup users and keys
+                users.groups.ghaf = { };
+                users.users = {
+                  ghaf = {
+                    isNormalUser = true;
+                    group = "ghaf";
+                    openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+                  };
+                };
+
+                services.getty.autologinUser = "ghaf";
+                # End of users
 
                 networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
                   {
-                    address = addrs.host;
+                    address = addrs.guivm;
                     prefixLength = 24;
                   }
                 ];
-                givc.host = {
-                  enable = true;
-                  transport = {
-                    name = "ghaf-host";
-                    addr = addrs.host;
-                    port = "9000";
-                    protocol = "tcp";
+                environment = {
+                  systemPackages = with pkgs; [ waypipe ];
+                  variables = {
+                    # Use a fixed SWAYSOCK path (for swaymsg):
+                    "SWAYSOCK" = "/tmp/sway-ipc.sock";
+                    # virtio-gpu and Virgil). We currently have to use the Pixman software
+                    # renderer since the GLES2 renderer doesn't work inside the VM
+                    "WLR_RENDERER" = "pixman";
                   };
+                };
+                # Automatically configure and start Sway when logging in on tty1:
+                programs.bash.loginShellInit = ''
+                  # Also configure a ssh private key, before run sway
+                  install -d -m700 .ssh
+                  install -m600 ${snakeOilPrivateKey} .ssh/id_rsa
+
+                  if [ "$(tty)" = "/dev/tty1" ]; then
+                    set -e
+
+                    mkdir -p ~/.config/sway
+                    sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
+
+                    sway --validate
+                    sway && touch /tmp/sway-exit-ok
+                  fi
+                '';
+                programs.sway.enable = true;
+                programs.ssh.extraConfig = ''
+                  UserKnownHostsFile=/dev/null
+                  StrictHostKeyChecking=no
+                '';
+                givc.sysvm = {
+                  enable = true;
                   admin = lib.head adminConfig.addresses;
+                  transport = {
+                    addr = addrs.guivm;
+                    name = "gui-vm";
+                  };
+                  tls.enable = tls;
                   services = [
                     "poweroff.target"
                     "reboot.target"
                     "sleep.target"
                     "suspend.target"
                   ];
-                  appVms = [
-                    "microvm@app-vm.service"
-                  ];
-                  tls.enable = tls;
                 };
-                systemd.services."microvm@app-vm" = {
-                  script = ''
-                    # Do nothing script, simulating microvm service
-                    while true; do sleep 10; done
-                  '';
+
+                # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
+                virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+              };
+            appvm =
+              { pkgs, ... }:
+              let
+                inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs) snakeOilPublicKey;
+              in
+              {
+                imports = [
+                  self.nixosModules.appvm
+                  ./snakeoil/gen-test-certs.nix
+                ];
+
+                # TLS parameter
+                givc-tls-test = {
+                  name = "app-vm";
+                  addresses = addrs.appvm;
+                };
+                users.groups.ghaf = { };
+                users.users = {
+                  ghaf = {
+                    isNormalUser = true;
+                    group = "ghaf";
+                    openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+                    linger = true;
+                  };
+                };
+                networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+                  {
+                    address = addrs.appvm;
+                    prefixLength = 24;
+                  }
+                ];
+                environment = {
+                  systemPackages = with pkgs; [
+                    # givc-agent expects /run/current-system/sw/bin/run-waypipe
+                    (pkgs.writeScriptBin "run-waypipe" ''
+                      #!${pkgs.runtimeShell} -e
+                      ${pkgs.waypipe}/bin/waypipe --socket /tmp/vsock server -- "$@"
+                    '')
+                    foot
+                    waypipe
+                  ];
+                };
+                services.openssh.enable = true;
+                givc.appvm = {
+                  enable = true;
+                  debug = true;
+                  transport = {
+                    name = "app-vm";
+                    addr = addrs.appvm;
+                  };
+                  admin = lib.head adminConfig.addresses;
+                  tls = {
+                    enable = tls;
+                    caCertPath = lib.mkForce "/etc/givc/ca-cert.pem";
+                    certPath = lib.mkForce "/etc/givc/cert.pem";
+                    keyPath = lib.mkForce "/etc/givc/key.pem";
+                  };
+                  applications = [
+                    {
+                      name = "foot";
+                      command = "/run/current-system/sw/bin/run-waypipe ${pkgs.foot}/bin/foot";
+                    }
+                    {
+                      name = "clearexit";
+                      command = "/run/current-system/sw/bin/sleep 5";
+                    }
+                  ];
                 };
               };
-              guivm =
-                { pkgs, ... }:
-                let
-                  inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs)
-                    snakeOilPrivateKey
-                    snakeOilPublicKey
-                    ;
-                in
-                {
-                  imports = [
-                    self.nixosModules.sysvm
-                    ./snakeoil/gen-test-certs.nix
-                  ];
-
-                  # TLS parameter
-                  givc-tls-test = {
-                    name = "gui-vm";
-                    addresses = addrs.guivm;
-                  };
-                  # Setup users and keys
-                  users.groups.ghaf = { };
-                  users.users = {
-                    ghaf = {
-                      isNormalUser = true;
-                      group = "ghaf";
-                      openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
-                    };
-                  };
-
-                  services.getty.autologinUser = "ghaf";
-                  # End of users
-
-                  networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-                    {
-                      address = addrs.guivm;
-                      prefixLength = 24;
-                    }
-                  ];
-                  environment = {
-                    systemPackages = with pkgs; [ waypipe ];
-                    variables = {
-                      # Use a fixed SWAYSOCK path (for swaymsg):
-                      "SWAYSOCK" = "/tmp/sway-ipc.sock";
-                      # virtio-gpu and Virgil). We currently have to use the Pixman software
-                      # renderer since the GLES2 renderer doesn't work inside the VM
-                      "WLR_RENDERER" = "pixman";
-                    };
-                  };
-                  # Automatically configure and start Sway when logging in on tty1:
-                  programs.bash.loginShellInit = ''
-                    # Also configure a ssh private key, before run sway
-                    install -d -m700 .ssh
-                    install -m600 ${snakeOilPrivateKey} .ssh/id_rsa
-
-                    if [ "$(tty)" = "/dev/tty1" ]; then
-                      set -e
-
-                      mkdir -p ~/.config/sway
-                      sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
-
-                      sway --validate
-                      sway && touch /tmp/sway-exit-ok
-                    fi
-                  '';
-                  programs.sway.enable = true;
-                  programs.ssh.extraConfig = ''
-                    UserKnownHostsFile=/dev/null
-                    StrictHostKeyChecking=no
-                  '';
-                  givc.sysvm = {
-                    enable = true;
-                    admin = lib.head adminConfig.addresses;
-                    transport = {
-                      addr = addrs.guivm;
-                      name = "gui-vm";
-                    };
-                    tls.enable = tls;
-                    services = [
-                      "poweroff.target"
-                      "reboot.target"
-                      "sleep.target"
-                      "suspend.target"
-                    ];
-                  };
-
-                  # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
-                  virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
-                };
-              appvm =
-                { pkgs, ... }:
-                let
-                  inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs) snakeOilPublicKey;
-                in
-                {
-                  imports = [
-                    self.nixosModules.appvm
-                    ./snakeoil/gen-test-certs.nix
-                  ];
-
-                  # TLS parameter
-                  givc-tls-test = {
-                    name = "app-vm";
-                    addresses = addrs.appvm;
-                  };
-                  users.groups.ghaf = { };
-                  users.users = {
-                    ghaf = {
-                      isNormalUser = true;
-                      group = "ghaf";
-                      openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
-                      linger = true;
-                    };
-                  };
-                  networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-                    {
-                      address = addrs.appvm;
-                      prefixLength = 24;
-                    }
-                  ];
-                  environment = {
-                    systemPackages = with pkgs; [
-                      # givc-agent expects /run/current-system/sw/bin/run-waypipe
-                      (pkgs.writeScriptBin "run-waypipe" ''
-                        #!${pkgs.runtimeShell} -e
-                        ${pkgs.waypipe}/bin/waypipe --socket /tmp/vsock server -- "$@"
-                      '')
-                      foot
-                      waypipe
-                    ];
-                  };
-                  services.openssh.enable = true;
-                  givc.appvm = {
-                    enable = true;
-                    debug = true;
-                    transport = {
-                      name = "app-vm";
-                      addr = addrs.appvm;
-                    };
-                    admin = lib.head adminConfig.addresses;
-                    tls = {
-                      enable = tls;
-                      caCertPath = lib.mkForce "/etc/givc/ca-cert.pem";
-                      certPath = lib.mkForce "/etc/givc/cert.pem";
-                      keyPath = lib.mkForce "/etc/givc/key.pem";
-                    };
-                    applications = [
-                      {
-                        name = "foot";
-                        command = "/run/current-system/sw/bin/run-waypipe ${pkgs.foot}/bin/foot";
-                      }
-                      {
-                        name = "clearexit";
-                        command = "/run/current-system/sw/bin/sleep 5";
-                      }
-                    ];
-                  };
-                };
-            };
-            testScript =
-              _:
-              let
-                cli = "${self'.packages.givc-admin.cli}/bin/givc-cli";
-                expected = "givc-ghaf-host.service"; # Name which we _expect_ to see registered in admin server's registry
-                cliArgs =
-                  "--name ${admin.name} --addr ${admin.addr} --port ${admin.port} "
-                  + "${
-                    if tls then
-                      "--cacert /etc/givc/ca-cert.pem --cert /etc/givc/cert.pem --key /etc/givc/key.pem"
-                    else
-                      "--notls"
-                  }";
-              in
-              # FIXME: why it so bizzare? (derived from name in cert)
-              ''
-                # Code below borrowed from $nixpkgs/nixos/tests/sway.nix
-                import shlex
-                import json
-                import re
-
-                q = shlex.quote
-                NODE_GROUPS = ["nodes", "floating_nodes"]
-                color_default = '\033[0m'
-                color_blue = '\033[94m'
-                color_red = '\033[91m'
-
-
-                def swaymsg(command: str = "", succeed=True, type="command", machine = guivm):
-                    assert command != "" or type != "command", "Must specify command or type"
-                    shell = q(f"swaymsg -t {q(type)} -- {q(command)}")
-                    with machine.nested(
-                        f"sending swaymsg {shell!r}" + " (allowed to fail)" * (not succeed)
-                    ):
-                        run = machine.succeed if succeed else machine.execute
-                        ret = run(
-                            f"su - ghaf -c {shell}"
-                        )
-
-                    # execute also returns a status code, but disregard.
-                    if not succeed:
-                        _, ret = ret
-
-                    if not succeed and not ret:
-                        return None
-
-                    parsed = json.loads(ret)
-                    return parsed
-
-
-                def walk(tree):
-                    yield tree
-                    for group in NODE_GROUPS:
-                        for node in tree.get(group, []):
-                            yield from walk(node)
-
-
-                def wait_for_window(pattern):
-                    def func(last_chance):
-                        nodes = (node["name"] for node in walk(swaymsg(type="get_tree")))
-
-                        if last_chance:
-                            nodes = list(nodes)
-                            guivm.log(f"Last call! Current list of windows: {nodes}")
-
-                        return any(pattern in name for name in nodes)
-
-                    retry(func, timeout=30)
-                # End of borrowed code
-
-                def by_name(name, js):
-                    for each in js:
-                        if each["name"] == name:
-                            return each
-                    raise KeyError(name)
-
-                import time
-                with subtest("setup services"):
-                    hostvm.wait_for_unit("givc-ghaf-host.service")
-                    adminvm.wait_for_unit("givc-admin.service")
-                    guivm.wait_for_unit("multi-user.target")
-                    appvm.wait_for_unit("multi-user.target")
-                    guivm.wait_for_unit("givc-gui-vm.service")
-
-                    time.sleep(1)
-                    # Ensure, that hostvm's agent registered in admin service. It take ~10 seconds to spin up and register itself
-                    print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 0 ${expected}"))
-                    print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 --vm app-vm microvm@app-vm.service"))
-
-                with subtest("setup gui vm"):
-                    # Ensure that sway in guiVM finished startup
-                    guivm.wait_for_file("/run/user/1000/wayland-1")
-                    guivm.wait_for_file("/tmp/sway-ipc.sock")
-
-                with subtest("setup ssh and keys"):
-                    swaymsg("exec ssh ${addrs.appvm} true && touch /tmp/ssh-ok")
-                    guivm.wait_for_file("/tmp/ssh-ok")
-                    swaymsg("exec waypipe --socket /tmp/vsock client")
-                    guivm.wait_for_file("/tmp/vsock")
-                    swaymsg("exec ssh -R /tmp/vsock:/tmp/vsock -f -N ${addrs.appvm}")
-                    time.sleep(5) # Give ssh some time to setup remote socket
-
-                with subtest("set locale and timezone"):
-                    print(hostvm.succeed("${cli} ${cliArgs} set-locale en_US.UTF-8"))
-                    adminvm.wait_for_file("/etc/locale-givc.conf")
-                    print(hostvm.succeed("${cli} ${cliArgs} set-timezone UTC"))
-                    adminvm.wait_for_file("/etc/timezone.conf")
-
-                with subtest("get stats"):
-                    print(hostvm.succeed("${cli} ${cliArgs} get-stats app-vm"))
-
-                with subtest("policy query for usb camera"):
-                    policy_input_storage_json = json.dumps({
-                      "input": {
-                        "usb_device": {
-                          "device_type": "camera",
-                          "vid": "0x0951",
-                          "pid": "0x1666"
-                        }
-                      }
-                    })
-                    policy_path = "ghaf/usb/access/allowed_vms"
-                    givc_cmd = f"${cli} ${cliArgs} policy-query '{policy_path}' '{policy_input_storage_json}'"
-                    result_json = hostvm.succeed(givc_cmd)
-                    match = re.search(r'result:\s*"(.*?)"\s*}', result_json)
-                    if not match:
-                        raise AssertionError(f"Could not extract result string from raw output: {result_json}")
-
-                    # The captured group contains the JSON string (potentially with escaped quotes)
-                    result_string_content = match.group(1)
-
-                    expected_result = "[\\\"guivm\\\"]"
-                    print(f"Expected: {expected_result}, Retrieved: {result_string_content} ")
-                    if result_string_content == expected_result:
-                        print(color_blue + "[TEST] Policy query for usb camera : PASSED" + color_default)
-                    else:
-                        print(color_red + "[TEST] Policy query for usb camera : FAILED" + color_default)
-
-                with subtest("Clean run"):
-                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm foot"))
-                    time.sleep(10) # Give few seconds to application to spin up
-                    wait_for_window("ghaf@appvm")
-
-                with subtest("crash and restart"):
-                    # Crash application
-                    appvm.succeed("pkill foot")
-                    time.sleep(10)
-                    # .. then ask to restart
-                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm foot"))
-                    wait_for_window("ghaf@appvm")
-
-                with subtest("pause/resume/stop application"):
-                    appvm.succeed("pgrep foot")
-                    print(hostvm.succeed("${cli} ${cliArgs} pause foot@1.service"))
-                    time.sleep(20)
-                    js = hostvm.succeed("${cli} ${cliArgs} query-list --as-json 2>/dev/null")
-                    foot = by_name("foot@1.service", json.loads(js))
-                    assert foot["status"] == "Paused"
-                    res = appvm.succeed("cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-foot.slice/foot@1.service/cgroup.events")
-                    assert "frozen 1" in res
-
-                    print(hostvm.succeed("${cli} ${cliArgs} resume foot@1.service"))
-                    time.sleep(20)
-                    res = appvm.succeed("cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-foot.slice/foot@1.service/cgroup.events")
-                    assert "frozen 0" in res
-                    js = hostvm.succeed("${cli} ${cliArgs} query-list --as-json 2>/dev/null")
-                    foot = by_name("foot@1.service", json.loads(js))
-                    assert foot["status"] == "Running"
-
-                    print(hostvm.succeed("${cli} ${cliArgs} stop foot@1.service"))
-                    appvm.fail("pgrep foot")
-
-                with subtest("clear exit and restart"):
-                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm clearexit"))
-                    time.sleep(20) # Give few seconds to application to spin up, exit, then start it again
-                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm clearexit"))
-              '';
           };
+          testScript =
+            _:
+            let
+              cli = "${self'.packages.givc-admin.cli}/bin/givc-cli";
+              expected = "givc-ghaf-host.service"; # Name which we _expect_ to see registered in admin server's registry
+              cliArgs =
+                "--name ${admin.name} --addr ${admin.addr} --port ${admin.port} "
+                + "${
+                  if tls then
+                    "--cacert /etc/givc/ca-cert.pem --cert /etc/givc/cert.pem --key /etc/givc/key.pem"
+                  else
+                    "--notls"
+                }";
+            in
+            # FIXME: why it so bizzare? (derived from name in cert)
+            ''
+              # Code below borrowed from $nixpkgs/nixos/tests/sway.nix
+              import shlex
+              import json
+
+              q = shlex.quote
+              NODE_GROUPS = ["nodes", "floating_nodes"]
+              color_default = '\033[0m'
+              color_blue = '\033[94m'
+              color_red = '\033[91m'
+
+
+              def swaymsg(command: str = "", succeed=True, type="command", machine = guivm):
+                  assert command != "" or type != "command", "Must specify command or type"
+                  shell = q(f"swaymsg -t {q(type)} -- {q(command)}")
+                  with machine.nested(
+                      f"sending swaymsg {shell!r}" + " (allowed to fail)" * (not succeed)
+                  ):
+                      run = machine.succeed if succeed else machine.execute
+                      ret = run(
+                          f"su - ghaf -c {shell}"
+                      )
+
+                  # execute also returns a status code, but disregard.
+                  if not succeed:
+                      _, ret = ret
+
+                  if not succeed and not ret:
+                      return None
+
+                  parsed = json.loads(ret)
+                  return parsed
+
+
+              def walk(tree):
+                  yield tree
+                  for group in NODE_GROUPS:
+                      for node in tree.get(group, []):
+                          yield from walk(node)
+
+
+              def wait_for_window(pattern):
+                  def func(last_chance):
+                      nodes = (node["name"] for node in walk(swaymsg(type="get_tree")))
+
+                      if last_chance:
+                          nodes = list(nodes)
+                          guivm.log(f"Last call! Current list of windows: {nodes}")
+
+                      return any(pattern in name for name in nodes)
+
+                  retry(func, timeout=30)
+              # End of borrowed code
+
+              def by_name(name, js):
+                  for each in js:
+                      if each["name"] == name:
+                          return each
+                  raise KeyError(name)
+
+              import time
+              with subtest("setup services"):
+                  hostvm.wait_for_unit("givc-ghaf-host.service")
+                  adminvm.wait_for_unit("givc-admin.service")
+                  guivm.wait_for_unit("multi-user.target")
+                  appvm.wait_for_unit("multi-user.target")
+                  guivm.wait_for_unit("givc-gui-vm.service")
+
+                  time.sleep(1)
+                  # Ensure, that hostvm's agent registered in admin service. It take ~10 seconds to spin up and register itself
+                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 0 ${expected}"))
+                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 --vm app-vm microvm@app-vm.service"))
+
+              with subtest("setup gui vm"):
+                  # Ensure that sway in guiVM finished startup
+                  guivm.wait_for_file("/run/user/1000/wayland-1")
+                  guivm.wait_for_file("/tmp/sway-ipc.sock")
+
+              with subtest("setup ssh and keys"):
+                  swaymsg("exec ssh ${addrs.appvm} true && touch /tmp/ssh-ok")
+                  guivm.wait_for_file("/tmp/ssh-ok")
+                  swaymsg("exec waypipe --socket /tmp/vsock client")
+                  guivm.wait_for_file("/tmp/vsock")
+                  swaymsg("exec ssh -R /tmp/vsock:/tmp/vsock -f -N ${addrs.appvm}")
+                  time.sleep(5) # Give ssh some time to setup remote socket
+
+              with subtest("set locale and timezone"):
+                  print(hostvm.succeed("${cli} ${cliArgs} set-locale en_US.UTF-8"))
+                  adminvm.wait_for_file("/etc/locale-givc.conf")
+                  print(hostvm.succeed("${cli} ${cliArgs} set-timezone UTC"))
+                  adminvm.wait_for_file("/etc/timezone.conf")
+
+              with subtest("get stats"):
+                  print(hostvm.succeed("${cli} ${cliArgs} get-stats app-vm"))
+
+              with subtest("USB hot plug policy"):
+                  usb_storage_cmd = "cmd:fetch ghaf/usb/hotplug_rules/get_rules"
+                  givc_cmd = f"${cli} ${cliArgs} policy-query '{usb_storage_cmd}'"
+                  res = hostvm.succeed(givc_cmd)
+                  #result_json = res.replace("PolicyQueryResponse", "")
+                  try:
+                      outer = json.loads(res) 
+                      inner = json.loads(outer)
+                      result = inner["result"]
+                      for vm in result:
+                          print(vm["name"])
+                  except json.JSONDecodeError as e:
+                      print(f"Failed to parse JSON: {e}")
+                      print(f"Raw response: {res}")
+            '';
         };
+      };
     };
 }

--- a/nixos/tests/admin.nix
+++ b/nixos/tests/admin.nix
@@ -26,390 +26,456 @@ let
     ];
   };
   admin = lib.head adminConfig.addresses;
+  opaUSBPolicy = ''
+    package ghaf.usb.access
+
+    # Partial set rule: allows accumulating multiple values in the set
+    allowed_vms[vm] {
+      input.usb_device.device_type == "storage"
+      _ := input.usb_device.vid
+      _ := input.usb_device.pid
+      vm := "appvm"
+    }
+
+    allowed_vms[vm] {
+      input.usb_device.device_type == "storage"
+      _ := input.usb_device.vid
+      _ := input.usb_device.pid
+      vm := "guivm"
+    }
+
+    allowed_vms[vm] {
+      input.usb_device.device_type == "camera"
+      _ := input.usb_device.vid
+      _ := input.usb_device.pid
+      vm := "guivm"
+    }
+  '';
 in
 {
   perSystem =
     { self', ... }:
     {
-      vmTests.tests.admin = {
-        module = {
-          nodes = {
-            adminvm = {
-              imports = [
-                self.nixosModules.admin
-                ./snakeoil/gen-test-certs.nix
-              ];
-
-              # TLS parameter
-              givc-tls-test = {
-                inherit (admin) name;
-                addresses = admin.addr;
-              };
-
-              networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-                {
-                  address = addrs.adminvm;
-                  prefixLength = 24;
-                }
-              ];
-              givc.admin = {
-                enable = true;
-                debug = true;
-                inherit (adminConfig) name;
-                inherit (adminConfig) addresses;
-                tls.enable = tls;
-              };
-            };
-            hostvm = {
-              imports = [
-                self.nixosModules.host
-                ./snakeoil/gen-test-certs.nix
-              ];
-
-              # TLS parameter
-              givc-tls-test = {
-                name = "ghaf-host";
-                addresses = addrs.host;
-              };
-
-              networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-                {
-                  address = addrs.host;
-                  prefixLength = 24;
-                }
-              ];
-              givc.host = {
-                enable = true;
-                transport = {
-                  name = "ghaf-host";
-                  addr = addrs.host;
-                  port = "9000";
-                  protocol = "tcp";
-                };
-                admin = lib.head adminConfig.addresses;
-                services = [
-                  "poweroff.target"
-                  "reboot.target"
-                  "sleep.target"
-                  "suspend.target"
-                ];
-                appVms = [
-                  "microvm@app-vm.service"
-                ];
-                tls.enable = tls;
-              };
-              systemd.services."microvm@app-vm" = {
-                script = ''
-                  # Do nothing script, simulating microvm service
-                  while true; do sleep 10; done
-                '';
-              };
-            };
-            guivm =
-              { pkgs, ... }:
-              let
-                inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs)
-                  snakeOilPrivateKey
-                  snakeOilPublicKey
-                  ;
-              in
-              {
+      vmTests.tests.admin =
+        let
+          policyPath = "/etc/opa/policies";
+        in
+        {
+          module = {
+            nodes = {
+              adminvm = {
                 imports = [
-                  self.nixosModules.sysvm
+                  self.nixosModules.admin
                   ./snakeoil/gen-test-certs.nix
                 ];
 
                 # TLS parameter
                 givc-tls-test = {
-                  name = "gui-vm";
-                  addresses = addrs.guivm;
+                  inherit (admin) name;
+                  addresses = admin.addr;
                 };
-                # Setup users and keys
-                users.groups.ghaf = { };
-                users.users = {
-                  ghaf = {
-                    isNormalUser = true;
-                    group = "ghaf";
-                    openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
-                  };
-                };
-
-                services.getty.autologinUser = "ghaf";
-                # End of users
 
                 networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
                   {
-                    address = addrs.guivm;
+                    address = addrs.adminvm;
                     prefixLength = 24;
                   }
                 ];
-                environment = {
-                  systemPackages = with pkgs; [ waypipe ];
-                  variables = {
-                    # Use a fixed SWAYSOCK path (for swaymsg):
-                    "SWAYSOCK" = "/tmp/sway-ipc.sock";
-                    # virtio-gpu and Virgil). We currently have to use the Pixman software
-                    # renderer since the GLES2 renderer doesn't work inside the VM
-                    "WLR_RENDERER" = "pixman";
+
+                givc.admin = {
+                  enable = true;
+                  debug = true;
+                  inherit (adminConfig) name;
+                  inherit (adminConfig) addresses;
+                  tls.enable = tls;
+                  opa = {
+                    enable = true;
+                    policies = policyPath;
                   };
                 };
-                # Automatically configure and start Sway when logging in on tty1:
-                programs.bash.loginShellInit = ''
-                  # Also configure a ssh private key, before run sway
-                  install -d -m700 .ssh
-                  install -m600 ${snakeOilPrivateKey} .ssh/id_rsa
+                environment.etc."opa/policies/usb-access.rego".text = opaUSBPolicy;
+              };
+              hostvm = {
+                imports = [
+                  self.nixosModules.host
+                  ./snakeoil/gen-test-certs.nix
+                ];
 
-                  if [ "$(tty)" = "/dev/tty1" ]; then
-                    set -e
+                # TLS parameter
+                givc-tls-test = {
+                  name = "ghaf-host";
+                  addresses = addrs.host;
+                };
 
-                    mkdir -p ~/.config/sway
-                    sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
-
-                    sway --validate
-                    sway && touch /tmp/sway-exit-ok
-                  fi
-                '';
-                programs.sway.enable = true;
-                programs.ssh.extraConfig = ''
-                  UserKnownHostsFile=/dev/null
-                  StrictHostKeyChecking=no
-                '';
-                givc.sysvm = {
+                networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+                  {
+                    address = addrs.host;
+                    prefixLength = 24;
+                  }
+                ];
+                givc.host = {
                   enable = true;
-                  admin = lib.head adminConfig.addresses;
                   transport = {
-                    addr = addrs.guivm;
-                    name = "gui-vm";
+                    name = "ghaf-host";
+                    addr = addrs.host;
+                    port = "9000";
+                    protocol = "tcp";
                   };
-                  tls.enable = tls;
+                  admin = lib.head adminConfig.addresses;
                   services = [
                     "poweroff.target"
                     "reboot.target"
                     "sleep.target"
                     "suspend.target"
                   ];
-                };
-
-                # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
-                virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
-              };
-            appvm =
-              { pkgs, ... }:
-              let
-                inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs) snakeOilPublicKey;
-              in
-              {
-                imports = [
-                  self.nixosModules.appvm
-                  ./snakeoil/gen-test-certs.nix
-                ];
-
-                # TLS parameter
-                givc-tls-test = {
-                  name = "app-vm";
-                  addresses = addrs.appvm;
-                };
-                users.groups.ghaf = { };
-                users.users = {
-                  ghaf = {
-                    isNormalUser = true;
-                    group = "ghaf";
-                    openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
-                    linger = true;
-                  };
-                };
-                networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-                  {
-                    address = addrs.appvm;
-                    prefixLength = 24;
-                  }
-                ];
-                environment = {
-                  systemPackages = with pkgs; [
-                    # givc-agent expects /run/current-system/sw/bin/run-waypipe
-                    (pkgs.writeScriptBin "run-waypipe" ''
-                      #!${pkgs.runtimeShell} -e
-                      ${pkgs.waypipe}/bin/waypipe --socket /tmp/vsock server -- "$@"
-                    '')
-                    foot
-                    waypipe
+                  appVms = [
+                    "microvm@app-vm.service"
                   ];
+                  tls.enable = tls;
                 };
-                services.openssh.enable = true;
-                givc.appvm = {
-                  enable = true;
-                  debug = true;
-                  transport = {
+                systemd.services."microvm@app-vm" = {
+                  script = ''
+                    # Do nothing script, simulating microvm service
+                    while true; do sleep 10; done
+                  '';
+                };
+              };
+              guivm =
+                { pkgs, ... }:
+                let
+                  inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs)
+                    snakeOilPrivateKey
+                    snakeOilPublicKey
+                    ;
+                in
+                {
+                  imports = [
+                    self.nixosModules.sysvm
+                    ./snakeoil/gen-test-certs.nix
+                  ];
+
+                  # TLS parameter
+                  givc-tls-test = {
+                    name = "gui-vm";
+                    addresses = addrs.guivm;
+                  };
+                  # Setup users and keys
+                  users.groups.ghaf = { };
+                  users.users = {
+                    ghaf = {
+                      isNormalUser = true;
+                      group = "ghaf";
+                      openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+                    };
+                  };
+
+                  services.getty.autologinUser = "ghaf";
+                  # End of users
+
+                  networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+                    {
+                      address = addrs.guivm;
+                      prefixLength = 24;
+                    }
+                  ];
+                  environment = {
+                    systemPackages = with pkgs; [ waypipe ];
+                    variables = {
+                      # Use a fixed SWAYSOCK path (for swaymsg):
+                      "SWAYSOCK" = "/tmp/sway-ipc.sock";
+                      # virtio-gpu and Virgil). We currently have to use the Pixman software
+                      # renderer since the GLES2 renderer doesn't work inside the VM
+                      "WLR_RENDERER" = "pixman";
+                    };
+                  };
+                  # Automatically configure and start Sway when logging in on tty1:
+                  programs.bash.loginShellInit = ''
+                    # Also configure a ssh private key, before run sway
+                    install -d -m700 .ssh
+                    install -m600 ${snakeOilPrivateKey} .ssh/id_rsa
+
+                    if [ "$(tty)" = "/dev/tty1" ]; then
+                      set -e
+
+                      mkdir -p ~/.config/sway
+                      sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
+
+                      sway --validate
+                      sway && touch /tmp/sway-exit-ok
+                    fi
+                  '';
+                  programs.sway.enable = true;
+                  programs.ssh.extraConfig = ''
+                    UserKnownHostsFile=/dev/null
+                    StrictHostKeyChecking=no
+                  '';
+                  givc.sysvm = {
+                    enable = true;
+                    admin = lib.head adminConfig.addresses;
+                    transport = {
+                      addr = addrs.guivm;
+                      name = "gui-vm";
+                    };
+                    tls.enable = tls;
+                    services = [
+                      "poweroff.target"
+                      "reboot.target"
+                      "sleep.target"
+                      "suspend.target"
+                    ];
+                  };
+
+                  # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
+                  virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+                };
+              appvm =
+                { pkgs, ... }:
+                let
+                  inherit (import "${inputs.nixpkgs.outPath}/nixos/tests/ssh-keys.nix" pkgs) snakeOilPublicKey;
+                in
+                {
+                  imports = [
+                    self.nixosModules.appvm
+                    ./snakeoil/gen-test-certs.nix
+                  ];
+
+                  # TLS parameter
+                  givc-tls-test = {
                     name = "app-vm";
-                    addr = addrs.appvm;
+                    addresses = addrs.appvm;
                   };
-                  admin = lib.head adminConfig.addresses;
-                  tls = {
-                    enable = tls;
-                    caCertPath = lib.mkForce "/etc/givc/ca-cert.pem";
-                    certPath = lib.mkForce "/etc/givc/cert.pem";
-                    keyPath = lib.mkForce "/etc/givc/key.pem";
+                  users.groups.ghaf = { };
+                  users.users = {
+                    ghaf = {
+                      isNormalUser = true;
+                      group = "ghaf";
+                      openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+                      linger = true;
+                    };
                   };
-                  applications = [
+                  networking.interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
                     {
-                      name = "foot";
-                      command = "/run/current-system/sw/bin/run-waypipe ${pkgs.foot}/bin/foot";
-                    }
-                    {
-                      name = "clearexit";
-                      command = "/run/current-system/sw/bin/sleep 5";
+                      address = addrs.appvm;
+                      prefixLength = 24;
                     }
                   ];
+                  environment = {
+                    systemPackages = with pkgs; [
+                      # givc-agent expects /run/current-system/sw/bin/run-waypipe
+                      (pkgs.writeScriptBin "run-waypipe" ''
+                        #!${pkgs.runtimeShell} -e
+                        ${pkgs.waypipe}/bin/waypipe --socket /tmp/vsock server -- "$@"
+                      '')
+                      foot
+                      waypipe
+                    ];
+                  };
+                  services.openssh.enable = true;
+                  givc.appvm = {
+                    enable = true;
+                    debug = true;
+                    transport = {
+                      name = "app-vm";
+                      addr = addrs.appvm;
+                    };
+                    admin = lib.head adminConfig.addresses;
+                    tls = {
+                      enable = tls;
+                      caCertPath = lib.mkForce "/etc/givc/ca-cert.pem";
+                      certPath = lib.mkForce "/etc/givc/cert.pem";
+                      keyPath = lib.mkForce "/etc/givc/key.pem";
+                    };
+                    applications = [
+                      {
+                        name = "foot";
+                        command = "/run/current-system/sw/bin/run-waypipe ${pkgs.foot}/bin/foot";
+                      }
+                      {
+                        name = "clearexit";
+                        command = "/run/current-system/sw/bin/sleep 5";
+                      }
+                    ];
+                  };
                 };
-              };
+            };
+            testScript =
+              _:
+              let
+                cli = "${self'.packages.givc-admin.cli}/bin/givc-cli";
+                expected = "givc-ghaf-host.service"; # Name which we _expect_ to see registered in admin server's registry
+                cliArgs =
+                  "--name ${admin.name} --addr ${admin.addr} --port ${admin.port} "
+                  + "${
+                    if tls then
+                      "--cacert /etc/givc/ca-cert.pem --cert /etc/givc/cert.pem --key /etc/givc/key.pem"
+                    else
+                      "--notls"
+                  }";
+              in
+              # FIXME: why it so bizzare? (derived from name in cert)
+              ''
+                # Code below borrowed from $nixpkgs/nixos/tests/sway.nix
+                import shlex
+                import json
+                import re
+
+                q = shlex.quote
+                NODE_GROUPS = ["nodes", "floating_nodes"]
+                color_default = '\033[0m'
+                color_blue = '\033[94m'
+                color_red = '\033[91m'
+
+
+                def swaymsg(command: str = "", succeed=True, type="command", machine = guivm):
+                    assert command != "" or type != "command", "Must specify command or type"
+                    shell = q(f"swaymsg -t {q(type)} -- {q(command)}")
+                    with machine.nested(
+                        f"sending swaymsg {shell!r}" + " (allowed to fail)" * (not succeed)
+                    ):
+                        run = machine.succeed if succeed else machine.execute
+                        ret = run(
+                            f"su - ghaf -c {shell}"
+                        )
+
+                    # execute also returns a status code, but disregard.
+                    if not succeed:
+                        _, ret = ret
+
+                    if not succeed and not ret:
+                        return None
+
+                    parsed = json.loads(ret)
+                    return parsed
+
+
+                def walk(tree):
+                    yield tree
+                    for group in NODE_GROUPS:
+                        for node in tree.get(group, []):
+                            yield from walk(node)
+
+
+                def wait_for_window(pattern):
+                    def func(last_chance):
+                        nodes = (node["name"] for node in walk(swaymsg(type="get_tree")))
+
+                        if last_chance:
+                            nodes = list(nodes)
+                            guivm.log(f"Last call! Current list of windows: {nodes}")
+
+                        return any(pattern in name for name in nodes)
+
+                    retry(func, timeout=30)
+                # End of borrowed code
+
+                def by_name(name, js):
+                    for each in js:
+                        if each["name"] == name:
+                            return each
+                    raise KeyError(name)
+
+                import time
+                with subtest("setup services"):
+                    hostvm.wait_for_unit("givc-ghaf-host.service")
+                    adminvm.wait_for_unit("givc-admin.service")
+                    guivm.wait_for_unit("multi-user.target")
+                    appvm.wait_for_unit("multi-user.target")
+                    guivm.wait_for_unit("givc-gui-vm.service")
+
+                    time.sleep(1)
+                    # Ensure, that hostvm's agent registered in admin service. It take ~10 seconds to spin up and register itself
+                    print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 0 ${expected}"))
+                    print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 --vm app-vm microvm@app-vm.service"))
+
+                with subtest("setup gui vm"):
+                    # Ensure that sway in guiVM finished startup
+                    guivm.wait_for_file("/run/user/1000/wayland-1")
+                    guivm.wait_for_file("/tmp/sway-ipc.sock")
+
+                with subtest("setup ssh and keys"):
+                    swaymsg("exec ssh ${addrs.appvm} true && touch /tmp/ssh-ok")
+                    guivm.wait_for_file("/tmp/ssh-ok")
+                    swaymsg("exec waypipe --socket /tmp/vsock client")
+                    guivm.wait_for_file("/tmp/vsock")
+                    swaymsg("exec ssh -R /tmp/vsock:/tmp/vsock -f -N ${addrs.appvm}")
+                    time.sleep(5) # Give ssh some time to setup remote socket
+
+                with subtest("set locale and timezone"):
+                    print(hostvm.succeed("${cli} ${cliArgs} set-locale en_US.UTF-8"))
+                    adminvm.wait_for_file("/etc/locale-givc.conf")
+                    print(hostvm.succeed("${cli} ${cliArgs} set-timezone UTC"))
+                    adminvm.wait_for_file("/etc/timezone.conf")
+
+                with subtest("get stats"):
+                    print(hostvm.succeed("${cli} ${cliArgs} get-stats app-vm"))
+
+                with subtest("policy query for usb camera"):
+                    policy_input_storage_json = json.dumps({
+                      "input": {
+                        "usb_device": {
+                          "device_type": "camera",
+                          "vid": "0x0951",
+                          "pid": "0x1666"
+                        }
+                      }
+                    })
+                    policy_path = "ghaf/usb/access/allowed_vms"
+                    givc_cmd = f"${cli} ${cliArgs} policy-query '{policy_path}' '{policy_input_storage_json}'"
+                    result_json = hostvm.succeed(givc_cmd)
+                    match = re.search(r'result:\s*"(.*?)"\s*}', result_json)
+                    if not match:
+                        raise AssertionError(f"Could not extract result string from raw output: {result_json}")
+
+                    # The captured group contains the JSON string (potentially with escaped quotes)
+                    result_string_content = match.group(1)
+
+                    expected_result = "[\\\"guivm\\\"]"
+                    print(f"Expected: {expected_result}, Retrieved: {result_string_content} ")
+                    if result_string_content == expected_result:
+                        print(color_blue + "[TEST] Policy query for usb camera : PASSED" + color_default)
+                    else:
+                        print(color_red + "[TEST] Policy query for usb camera : FAILED" + color_default)
+
+                with subtest("Clean run"):
+                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm foot"))
+                    time.sleep(10) # Give few seconds to application to spin up
+                    wait_for_window("ghaf@appvm")
+
+                with subtest("crash and restart"):
+                    # Crash application
+                    appvm.succeed("pkill foot")
+                    time.sleep(10)
+                    # .. then ask to restart
+                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm foot"))
+                    wait_for_window("ghaf@appvm")
+
+                with subtest("pause/resume/stop application"):
+                    appvm.succeed("pgrep foot")
+                    print(hostvm.succeed("${cli} ${cliArgs} pause foot@1.service"))
+                    time.sleep(20)
+                    js = hostvm.succeed("${cli} ${cliArgs} query-list --as-json 2>/dev/null")
+                    foot = by_name("foot@1.service", json.loads(js))
+                    assert foot["status"] == "Paused"
+                    res = appvm.succeed("cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-foot.slice/foot@1.service/cgroup.events")
+                    assert "frozen 1" in res
+
+                    print(hostvm.succeed("${cli} ${cliArgs} resume foot@1.service"))
+                    time.sleep(20)
+                    res = appvm.succeed("cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-foot.slice/foot@1.service/cgroup.events")
+                    assert "frozen 0" in res
+                    js = hostvm.succeed("${cli} ${cliArgs} query-list --as-json 2>/dev/null")
+                    foot = by_name("foot@1.service", json.loads(js))
+                    assert foot["status"] == "Running"
+
+                    print(hostvm.succeed("${cli} ${cliArgs} stop foot@1.service"))
+                    appvm.fail("pgrep foot")
+
+                with subtest("clear exit and restart"):
+                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm clearexit"))
+                    time.sleep(20) # Give few seconds to application to spin up, exit, then start it again
+                    print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm clearexit"))
+              '';
           };
-          testScript =
-            _:
-            let
-              cli = "${self'.packages.givc-admin.cli}/bin/givc-cli";
-              expected = "givc-ghaf-host.service"; # Name which we _expect_ to see registered in admin server's registry
-              cliArgs =
-                "--name ${admin.name} --addr ${admin.addr} --port ${admin.port} "
-                + "${
-                  if tls then
-                    "--cacert /etc/givc/ca-cert.pem --cert /etc/givc/cert.pem --key /etc/givc/key.pem"
-                  else
-                    "--notls"
-                }";
-            in
-            # FIXME: why it so bizzare? (derived from name in cert)
-            ''
-              # Code below borrowed from $nixpkgs/nixos/tests/sway.nix
-              import shlex
-              import json
-
-              q = shlex.quote
-              NODE_GROUPS = ["nodes", "floating_nodes"]
-
-
-              def swaymsg(command: str = "", succeed=True, type="command", machine = guivm):
-                  assert command != "" or type != "command", "Must specify command or type"
-                  shell = q(f"swaymsg -t {q(type)} -- {q(command)}")
-                  with machine.nested(
-                      f"sending swaymsg {shell!r}" + " (allowed to fail)" * (not succeed)
-                  ):
-                      run = machine.succeed if succeed else machine.execute
-                      ret = run(
-                          f"su - ghaf -c {shell}"
-                      )
-
-                  # execute also returns a status code, but disregard.
-                  if not succeed:
-                      _, ret = ret
-
-                  if not succeed and not ret:
-                      return None
-
-                  parsed = json.loads(ret)
-                  return parsed
-
-
-              def walk(tree):
-                  yield tree
-                  for group in NODE_GROUPS:
-                      for node in tree.get(group, []):
-                          yield from walk(node)
-
-
-              def wait_for_window(pattern):
-                  def func(last_chance):
-                      nodes = (node["name"] for node in walk(swaymsg(type="get_tree")))
-
-                      if last_chance:
-                          nodes = list(nodes)
-                          guivm.log(f"Last call! Current list of windows: {nodes}")
-
-                      return any(pattern in name for name in nodes)
-
-                  retry(func, timeout=30)
-              # End of borrowed code
-
-              def by_name(name, js):
-                  for each in js:
-                      if each["name"] == name:
-                          return each
-                  raise KeyError(name)
-
-              import time
-              with subtest("setup services"):
-                  hostvm.wait_for_unit("givc-ghaf-host.service")
-                  adminvm.wait_for_unit("givc-admin.service")
-                  guivm.wait_for_unit("multi-user.target")
-                  appvm.wait_for_unit("multi-user.target")
-                  guivm.wait_for_unit("givc-gui-vm.service")
-
-                  time.sleep(1)
-                  # Ensure, that hostvm's agent registered in admin service. It take ~10 seconds to spin up and register itself
-                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 0 ${expected}"))
-                  print(hostvm.succeed("${cli} ${cliArgs} test ensure --retry 60 --type 11 --vm app-vm microvm@app-vm.service"))
-
-              with subtest("setup gui vm"):
-                  # Ensure that sway in guiVM finished startup
-                  guivm.wait_for_file("/run/user/1000/wayland-1")
-                  guivm.wait_for_file("/tmp/sway-ipc.sock")
-
-              with subtest("setup ssh and keys"):
-                  swaymsg("exec ssh ${addrs.appvm} true && touch /tmp/ssh-ok")
-                  guivm.wait_for_file("/tmp/ssh-ok")
-                  swaymsg("exec waypipe --socket /tmp/vsock client")
-                  guivm.wait_for_file("/tmp/vsock")
-                  swaymsg("exec ssh -R /tmp/vsock:/tmp/vsock -f -N ${addrs.appvm}")
-                  time.sleep(5) # Give ssh some time to setup remote socket
-
-              with subtest("set locale and timezone"):
-                  print(hostvm.succeed("${cli} ${cliArgs} set-locale en_US.UTF-8"))
-                  adminvm.wait_for_file("/etc/locale-givc.conf")
-                  print(hostvm.succeed("${cli} ${cliArgs} set-timezone UTC"))
-                  adminvm.wait_for_file("/etc/timezone.conf")
-
-              with subtest("get stats"):
-                  print(hostvm.succeed("${cli} ${cliArgs} get-stats app-vm"))
-
-              with subtest("Clean run"):
-                  print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm foot"))
-                  time.sleep(10) # Give few seconds to application to spin up
-                  wait_for_window("ghaf@appvm")
-
-              with subtest("crash and restart"):
-                  # Crash application
-                  appvm.succeed("pkill foot")
-                  time.sleep(10)
-                  # .. then ask to restart
-                  print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm foot"))
-                  wait_for_window("ghaf@appvm")
-
-              with subtest("pause/resume/stop application"):
-                  appvm.succeed("pgrep foot")
-                  print(hostvm.succeed("${cli} ${cliArgs} pause foot@1.service"))
-                  time.sleep(20)
-                  js = hostvm.succeed("${cli} ${cliArgs} query-list --as-json 2>/dev/null")
-                  foot = by_name("foot@1.service", json.loads(js))
-                  assert foot["status"] == "Paused"
-                  res = appvm.succeed("cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-foot.slice/foot@1.service/cgroup.events")
-                  assert "frozen 1" in res
-
-                  print(hostvm.succeed("${cli} ${cliArgs} resume foot@1.service"))
-                  time.sleep(20)
-                  res = appvm.succeed("cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/app-foot.slice/foot@1.service/cgroup.events")
-                  assert "frozen 0" in res
-                  js = hostvm.succeed("${cli} ${cliArgs} query-list --as-json 2>/dev/null")
-                  foot = by_name("foot@1.service", json.loads(js))
-                  assert foot["status"] == "Running"
-
-                  print(hostvm.succeed("${cli} ${cliArgs} stop foot@1.service"))
-                  appvm.fail("pgrep foot")
-
-              with subtest("clear exit and restart"):
-                  print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm clearexit"))
-                  time.sleep(20) # Give few seconds to application to spin up, exit, then start it again
-                  print(hostvm.succeed("${cli} ${cliArgs} start app --vm app-vm clearexit"))
-            '';
         };
-      };
     };
 }


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description
Enable policy server in admin vm
 - Starts OPA server on admin vm
 - OPA server listens to local port only
 - givc-cli can be used to post query
 - A test is added for fake usb camera

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [x] Author has run `nix flake check` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing
Automated test is added in NixOS test framework.
To be tested in Ghaf