### PR TITLE
Add VM name to manager services

### DIFF
--- a/api/admin/admin.proto
+++ b/api/admin/admin.proto
@@ -18,7 +18,7 @@ message RegistryRequest {
     string Name = 1;                // Component name for registry entry
     string Parent = 2;              // Parent component identifier (registry name)
     uint32 Type = 3;                // Component type
-    TransportConfig Transport = 4;  // TransportConfig
+    TransportConfig Transport = 4;  // `TransportConfig`
     systemd.UnitStatus State = 5;   // Unit status of the component (systemd)
 }
 

--- a/api/locale/locale.proto
+++ b/api/locale/locale.proto
@@ -22,8 +22,8 @@ enum LocaleMacroKey {
 }
 
 message LocaleAssignment {
-    LocaleMacroKey key = 1;   // e.g., LC_TIME, LC_NUMERIC
-    string value = 2;         // e.g., en_US.UTF-8
+    LocaleMacroKey key = 1;   // e.g., `LC_TIME`, `LC_NUMERIC`
+    string value = 2;         // e.g., `en_US.UTF-8`
 }
 
 message LocaleMessage {

--- a/api/systemd/systemd.proto
+++ b/api/systemd/systemd.proto
@@ -7,9 +7,9 @@ package systemd;
 message UnitStatus {
     string Name = 1;                // Full systemd unit name
     string Description = 2;         // A short human readable title of the unit
-    string LoadState = 3;           // LoadState contains a state value that reflects whether the configuration file of this unit has been loaded
-    string ActiveState = 4;         // ActiveState contains a state value that reflects whether the unit is currently active or not
-    string SubState = 5;            // SubState encodes more fine-grained states that are unit-type-specific
+    string LoadState = 3;           // `LoadState` contains a state value that reflects whether the configuration file of this unit has been loaded
+    string ActiveState = 4;         // `ActiveState` contains a state value that reflects whether the unit is currently active or not
+    string SubState = 5;            // `SubState` encodes more fine-grained states that are unit-type-specific
     string Path = 6;                // Bus object path of the unit
     string FreezerState = 7;        // Freezer sub-state, indicates whether unit is frozen
 }

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Alexander Nikolaev <alexander.nikolaev@unikie.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache 2.0"
 name = "givc"
 publish = false

--- a/crates/admin/src/admin/entry.rs
+++ b/crates/admin/src/admin/entry.rs
@@ -108,8 +108,6 @@ impl TryFrom<pb::RegistryRequest> for RegistryEntry {
             .context("endpoint missing")
             .and_then(EndpointEntry::try_from)?;
         let watch = (ty.service == ServiceType::Mgr) || (ty.vm == VmType::AppVM);
-        // FIXME: We currently ignore `req.parent`, what we should do if we got both parent and endpoint
-        // Protocol very inconsistent here
         Ok(Self {
             name: req.name,
             status,
@@ -117,7 +115,7 @@ impl TryFrom<pb::RegistryRequest> for RegistryEntry {
             r#type: ty,
             placement: Placement::Endpoint {
                 endpoint,
-                vm: "bogus".into(),
+                vm: parse_vm_name(&req.parent).unwrap_or_default().into(),
             },
         })
     }

--- a/crates/admin/src/admin/entry.rs
+++ b/crates/admin/src/admin/entry.rs
@@ -45,7 +45,7 @@ impl RegistryEntry {
                 .name
                 .strip_prefix("microvm@")
                 .and_then(|name| name.strip_suffix(".service")),
-            (_, Placement::Endpoint { ref vm, .. } | Placement::Managed { ref vm, .. }) => Some(vm),
+            (_, Placement::Endpoint { vm, .. } | Placement::Managed { vm, .. }) => Some(vm),
             (_, Placement::Host) => None,
         }
     }

--- a/crates/admin/src/admin/entry.rs
+++ b/crates/admin/src/admin/entry.rs
@@ -1,7 +1,7 @@
 // This module contain literal translations of types from internal/pkgs/types/types.go
 // Some of them would be rewritten, replaced, or even removed
 use crate::pb;
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use std::convert::TryFrom;
 
 use crate::utils::naming::parse_vm_name;
@@ -101,11 +101,11 @@ impl TryFrom<pb::RegistryRequest> for RegistryEntry {
         let ty = UnitType::try_from(req.r#type)?;
         let status = req
             .state
-            .ok_or(anyhow!("status missing"))
+            .context("status missing")
             .and_then(UnitStatus::try_from)?;
         let endpoint = req
             .transport
-            .ok_or(anyhow!("endpoint missing"))
+            .context("endpoint missing")
             .and_then(EndpointEntry::try_from)?;
         let watch = (ty.service == ServiceType::Mgr) || (ty.vm == VmType::AppVM);
         // FIXME: We currently ignore `req.parent`, what we should do if we got both parent and endpoint

--- a/crates/admin/src/admin/entry.rs
+++ b/crates/admin/src/admin/entry.rs
@@ -4,6 +4,7 @@ use crate::pb;
 use anyhow::anyhow;
 use std::convert::TryFrom;
 
+use crate::utils::naming::parse_vm_name;
 use givc_common::query::{QueryResult, TrustLevel, VMStatus};
 use givc_common::types::{EndpointEntry, ServiceType, UnitStatus, UnitType, VmType};
 
@@ -41,10 +42,7 @@ impl RegistryEntry {
     #[must_use]
     pub(crate) fn vm_name(&self) -> Option<&str> {
         match (self.r#type.service, &self.placement) {
-            (ServiceType::VM, _) => self
-                .name
-                .strip_prefix("microvm@")
-                .and_then(|name| name.strip_suffix(".service")),
+            (ServiceType::VM, _) => parse_vm_name(&self.name),
             (_, Placement::Endpoint { vm, .. } | Placement::Managed { vm, .. }) => Some(vm),
             (_, Placement::Host) => None,
         }

--- a/crates/admin/src/admin/registry.rs
+++ b/crates/admin/src/admin/registry.rs
@@ -100,7 +100,15 @@ impl Registry {
         Ok(list)
     }
 
-    pub(crate) fn find_map<T, F: FnMut(&RegistryEntry) -> Option<T>>(&self, filter: F) -> Vec<T> {
+    pub(crate) fn find_map<T, F: FnMut(&RegistryEntry) -> Option<T>>(
+        &self,
+        filter: F,
+    ) -> Option<T> {
+        let state = self.map.lock().unwrap();
+        state.values().find_map(filter)
+    }
+
+    pub(crate) fn filter_map<T, F: FnMut(&RegistryEntry) -> Option<T>>(&self, filter: F) -> Vec<T> {
         let state = self.map.lock().unwrap();
         state.values().filter_map(filter).collect()
     }

--- a/crates/admin/src/admin/server.rs
+++ b/crates/admin/src/admin/server.rs
@@ -678,7 +678,7 @@ impl pb::admin_service_server::AdminService for AdminService {
                 .join("\n");
             let _ = tokio::fs::write(LOCALE_CONF, content).await;
 
-            let managers = self.inner.registry.find_map(|re| {
+            let managers = self.inner.registry.filter_map(|re| {
                 (re.r#type.service == ServiceType::Mgr)
                     .then_some(())
                     .and_then(|()| self.inner.endpoint(re).ok())
@@ -710,7 +710,7 @@ impl pb::admin_service_server::AdminService for AdminService {
                 bail!("Invalid timezone");
             }
             let _ = tokio::fs::write(TIMEZONE_CONF, &req.timezone).await;
-            let managers = self.inner.registry.find_map(|re| {
+            let managers = self.inner.registry.filter_map(|re| {
                 (re.r#type.service == ServiceType::Mgr)
                     .then_some(())
                     .and_then(|()| self.inner.endpoint(re).ok())
@@ -747,8 +747,6 @@ impl pb::admin_service_server::AdminService for AdminService {
                     (re.r#type.service == ServiceType::Mgr && re.name == vm_name)
                         .then(|| self.inner.endpoint(re))
                 })
-                .into_iter()
-                .next()
                 .with_context(|| format!("VM {vm_name} not found"))??;
             Ok(vm
                 .connect()

--- a/crates/admin/src/bin/givc-admin.rs
+++ b/crates/admin/src/bin/givc-admin.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::Parser;
 use givc::admin;
 use givc::endpoint::TlsConfig;
@@ -38,7 +39,7 @@ struct Cli {
 }
 
 #[tokio::main]
-async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn main() -> anyhow::Result<()> {
     givc::trace_init()?;
 
     let cli = Cli::parse();
@@ -48,9 +49,9 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     let tls = if cli.use_tls {
         let tls = TlsConfig {
-            ca_cert_file_path: cli.ca_cert.ok_or(String::from("required"))?,
-            cert_file_path: cli.host_cert.ok_or(String::from("required"))?,
-            key_file_path: cli.host_key.ok_or(String::from("required"))?,
+            ca_cert_file_path: cli.ca_cert.context("required")?,
+            cert_file_path: cli.host_cert.context("required")?,
+            key_file_path: cli.host_key.context("required")?,
             tls_name: None,
         };
         let tls_config = tls.server_config()?;

--- a/crates/admin/src/systemd_api/client.rs
+++ b/crates/admin/src/systemd_api/client.rs
@@ -1,4 +1,5 @@
 use crate::pb;
+use anyhow::Context;
 use givc_client::endpoint::EndpointConfig;
 use givc_client::error::StatusWrapExt;
 use pb::systemd::UnitResponse;
@@ -29,7 +30,7 @@ impl SystemDClient {
         let status = response
             .into_inner()
             .unit_status
-            .ok_or_else(|| anyhow::anyhow!("missing unit_status field"))?;
+            .context("missing unit_status field")?;
         let us = crate::types::UnitStatus {
             name: status.name,
             description: status.description,

--- a/crates/admin/src/utils/auth.rs
+++ b/crates/admin/src/utils/auth.rs
@@ -3,71 +3,66 @@ use tonic::{Request, Status};
 
 /// # Errors
 /// Return `Err(tonic::Status)` if IP in request have no certificate
-fn security_info_from_request(req: &Request<()>) -> Result<SecurityInfo, Status> {
-    if let Some(certs) = req.peer_certs() {
-        certs
-            .iter()
-            .find_map(|cert| SecurityInfo::try_from(cert.as_ref()).ok())
-            .ok_or(Status::unauthenticated("Can't determinate certificace"))
-    } else {
-        Err(Status::unauthenticated("No valid certificate"))
-    }
+fn security_info_from_request(req: &Request<()>) -> Result<SecurityInfo, Box<Status>> {
+    req.peer_certs()
+        .ok_or(Status::unauthenticated("No valid certificate"))?
+        .iter()
+        .find_map(|cert| SecurityInfo::try_from(cert.as_ref()).ok())
+        .ok_or(Status::unauthenticated("Can't determinate certificace").into())
 }
 
 /// # Errors
 /// Return `Err(tonic::Status)` if IP in request headers mismatch IP in certificate
-pub fn auth_interceptor(mut req: Request<()>) -> Result<Request<()>, Status> {
+pub fn auth_interceptor(mut req: Request<()>) -> Result<Request<()>, Box<Status>> {
     let info = security_info_from_request(&req)?;
-    if let Some(addr) = req.remote_addr() {
-        if info.check_address(&addr.ip()) {
-            req.extensions_mut().insert(info);
-            Ok(req)
-        } else {
-            Err(Status::permission_denied(format!(
-                "Address {addr} mismatched with address in certificate"
-            )))
-        }
+    let addr = req
+        .remote_addr()
+        .ok_or(Status::unauthenticated("Can't determine IP address"))?;
+    if info.check_address(&addr.ip()) {
+        req.extensions_mut().insert(info);
+        Ok(req)
     } else {
-        Err(Status::unauthenticated("Can't determine IP address"))
+        Err(Status::permission_denied(format!(
+            "Address {addr} mismatched with address in certificate"
+        ))
+        .into())
     }
 }
 
 /// # Errors
 /// This function always success and return `Ok()`
-pub fn no_auth_interceptor(mut req: Request<()>) -> Result<Request<()>, Status> {
+pub fn no_auth_interceptor(mut req: Request<()>) -> Result<Request<()>, Box<Status>> {
     req.extensions_mut().insert(SecurityInfo::disabled());
     Ok(req)
 }
 
 /// # Errors
 /// This function fails if hostname permission not confirmed by certificate
-pub fn ensure_host<R>(req: &Request<R>, hostname: &str) -> Result<(), Status> {
-    let permit = req
-        .extensions()
+pub fn ensure_host<R>(req: &Request<R>, hostname: &str) -> Result<(), Box<Status>> {
+    req.extensions()
         .get::<SecurityInfo>()
-        .is_some_and(|si| si.check_hostname(hostname));
-    if permit {
-        Ok(())
-    } else {
-        Err(Status::permission_denied(format!(
-            "Permissions for {hostname} not confirmed by certificate"
-        )))
-    }
+        .is_some_and(|si| si.check_hostname(hostname))
+        .then_some(())
+        .ok_or_else(|| {
+            Status::permission_denied(format!(
+                "Permissions for {hostname} not confirmed by certificate"
+            ))
+            .into()
+        })
 }
 
 /// # Errors
 /// This function fails if hostname permission not confirmed by certificate
-pub fn ensure_hosts<R>(req: &Request<R>, hostnames: &[&str]) -> Result<(), Status> {
-    let permit = req
-        .extensions()
+pub fn ensure_hosts<R>(req: &Request<R>, hostnames: &[&str]) -> Result<(), Box<Status>> {
+    req.extensions()
         .get::<SecurityInfo>()
-        .is_some_and(|si| hostnames.iter().any(|hostname| si.check_hostname(hostname)));
-    if permit {
-        Ok(())
-    } else {
-        Err(Status::permission_denied(format!(
-            "Permissions for {} not confirmed by certificate",
-            hostnames.join(", ")
-        )))
-    }
+        .is_some_and(|si| hostnames.iter().any(|hostname| si.check_hostname(hostname)))
+        .then_some(())
+        .ok_or_else(|| {
+            Status::permission_denied(format!(
+                "Permissions for {} not confirmed by certificate",
+                hostnames.join(", ")
+            ))
+            .into()
+        })
 }

--- a/crates/admin/src/utils/naming.rs
+++ b/crates/admin/src/utils/naming.rs
@@ -10,6 +10,11 @@ pub fn format_vm_name(name: &str, vm: Option<&str>) -> String {
 }
 
 #[must_use]
+pub fn parse_vm_name(name: &str) -> Option<&str> {
+    name.strip_prefix("microvm@")?.strip_suffix(".service")
+}
+
+#[must_use]
 pub fn format_service_name(name: &str, vm: Option<&str>) -> String {
     if let Some(vm_name) = vm {
         format!("givc-{vm_name}.service")

--- a/crates/admin/src/utils/naming.rs
+++ b/crates/admin/src/utils/naming.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, anyhow, bail};
+use anyhow::{Context, bail};
 
 #[must_use]
 pub fn format_vm_name(name: &str, vm: Option<&str>) -> String {
@@ -28,7 +28,7 @@ pub fn format_service_name(name: &str, vm: Option<&str>) -> String {
 pub fn parse_service_name(name: &str) -> anyhow::Result<&str> {
     name.strip_suffix("-vm.service")
         .and_then(|name| name.strip_prefix("givc-"))
-        .ok_or_else(|| anyhow!("Doesn't know how to parse VM name: {name}"))
+        .with_context(|| format!("Doesn't know how to parse VM name: {name}"))
 }
 
 /// From `agent` code, ported for future

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Alexander Nikolaev <alexander.nikolaev@unikie.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache 2.0"
 name = "givc-client"
 publish = false

--- a/crates/client/src/endpoint.rs
+++ b/crates/client/src/endpoint.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 use tokio_vsock::{VsockAddr, VsockStream};
@@ -41,10 +41,7 @@ impl TlsConfig {
         let client_cert = std::fs::read(&self.cert_file_path)?;
         let client_key = std::fs::read(&self.key_file_path)?;
         let client_identity = Identity::from_pem(client_cert, client_key);
-        let tls_name = self
-            .tls_name
-            .as_deref()
-            .ok_or_else(|| anyhow!("Missing TLS name"))?;
+        let tls_name = self.tls_name.as_deref().context("Missing TLS name")?;
         info!("Using TLS name: {tls_name}");
         Ok(ClientTlsConfig::new()
             .ca_certificate(ca)

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Alexander Nikolaev <alexander.nikolaev@unikie.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache 2.0"
 name = "givc-common"
 publish = false

--- a/crates/ota-update/Cargo.toml
+++ b/crates/ota-update/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Alexander Nikolaev <alexander.nikolaev@unikie.com>"]
-edition = "2021"
+edition = "2024"
 license = "Apache 2.0"
 name = "ota-update"
 publish = false

--- a/crates/ota-update/src/bin/ota-update.rs
+++ b/crates/ota-update/src/bin/ota-update.rs
@@ -66,7 +66,7 @@ fn get_generations() -> anyhow::Result<()> {
 fn is_valid_nix_path(path: &Path) -> anyhow::Result<()> {
     let path = path
         .to_str()
-        .ok_or_else(|| anyhow::anyhow!("unable to convert `{}` to UTF-8", path.display()))?;
+        .with_context(|| format!("unable to convert `{}` to UTF-8", path.display()))?;
     // nix hashes don't contain [eotu]
     let pattern = r"^/nix/store/[a-df-np-sv-z0-9]{32}-nixos-system-[^/]+$";
     let re = Regex::new(pattern).expect("Invalid regex");

--- a/crates/ota-update/src/bin/update-server.rs
+++ b/crates/ota-update/src/bin/update-server.rs
@@ -73,10 +73,7 @@ impl IntoResponse for Error {
     }
 }
 
-async fn get_update_list(
-    path: &Path,
-    default_name: &str,
-) -> Result<Vec<UpdateInfo>, anyhow::Error> {
+async fn get_update_list(path: &Path, default_name: &str) -> anyhow::Result<Vec<UpdateInfo>> {
     let default_link_path = path.join(default_name);
     let default_target = fs::read_link(&default_link_path).await.ok();
 

--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745929750,
-        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

Parse the VM name from parent field of a manager and use it as vm name

Also includes some clippy warning fixes, unifying `Option` -> `anyhow::Result` transformations and some code simplifications.

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [X] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [X] Author has run `nix flake check` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
