### PR TITLE
Avnik/ota bootctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "bootspec",
  "cachix-client",
  "clap",
+ "once_cell",
  "regex",
  "reqwest",
  "serde",

--- a/crates/ota-update/Cargo.toml
+++ b/crates/ota-update/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.86"
 axum = "*"
 bootspec = "*"
 clap = { version = "4.5.41", features = ["derive", "env"] }
+once_cell = "*"
 regex = "*"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/crates/ota-update/src/bin/update-server.rs
+++ b/crates/ota-update/src/bin/update-server.rs
@@ -14,9 +14,8 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::fs;
 use tokio::net::TcpListener;
-use tracing::{debug, info, trace};
+use tracing::{info, trace};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -79,42 +78,22 @@ async fn get_update_list(
         "Query updates for {path}, default {default_name}",
         path = path.display()
     );
-    let default_link_path = path.join(default_name);
-    let default_target = fs::read_link(&default_link_path).await.ok();
 
     let mut updates = Vec::new();
-    let mut dir = fs::read_dir(&path)
+    let (_, profiles) = profile::read_profile_links(path, default_name)
         .await
-        .with_context(|| format!("while read_dir() on {path}", path = path.display()))?;
+        .with_context(|| {
+            format!(
+                "While reading profile {path} with {default_name}",
+                path = path.display()
+            )
+        })?;
 
-    while let Some(entry) = dir.next_entry().await? {
-        debug!("Processing {entry:?}");
-
-        let name = entry
-            .file_name()
-            .into_string()
-            .ok()
-            .context("Decode UTF-8 string")?;
-        if name
-            .strip_prefix(default_name)
-            .is_none_or(|f| !f.ends_with("-link"))
-        {
-            continue;
-        }
-
-        let full_path = entry.path();
-
-        let store_path = match fs::read_link(&full_path).await {
-            Ok(t) if t.is_absolute() && t.exists() => t,
-            _ => continue,
-        };
-
-        let current = default_target.as_deref() == Some(name.as_ref());
-
+    for profile in profiles {
         updates.push(UpdateInfo {
-            name,
-            store_path,
-            current,
+            name: format!("Update #{num}", num = profile.num),
+            store_path: profile.store_path,
+            current: profile.current,
             pub_key: pub_key.to_owned(),
         });
     }

--- a/crates/ota-update/src/bootctl.rs
+++ b/crates/ota-update/src/bootctl.rs
@@ -1,0 +1,70 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use std::process::Stdio;
+use tokio::process::Command;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootctlItem {
+    pub r#type: String,
+    pub source: String,
+    pub id: String,
+    pub path: String,
+    pub root: String,
+    pub title: String,
+    pub show_title: String,
+    pub sort_key: String,
+    pub version: String,
+    pub machine_id: String,
+    pub options: String,
+    pub linux: String,
+    pub initrd: Vec<String>,
+    pub is_reported: bool,
+    pub is_default: bool,
+    pub is_selected: bool,
+    pub addon: Option<String>, // FIXME: didn't know real type of value. it == null in my experiments
+    pub cmdline: String,
+}
+
+type BootctlInfo = Vec<BootctlItem>;
+
+pub async fn get_bootctl_info() -> anyhow::Result<BootctlInfo> {
+    let bootctl = Command::new("bootctl")
+        .arg("list")
+        .arg("--json")
+        .arg("pretty")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("executing bootctl")?;
+    let output = bootctl
+        .wait_with_output()
+        .await
+        .context("Fail to capture stdout/stderr")?;
+
+    let err = String::from_utf8_lossy(&output.stderr);
+    match output
+        .status
+        .code()
+        .context("bootctl crashed/killed by signal")?
+    {
+        0 => {
+            let info = serde_json::from_slice(&output.stdout).context("Parsing bootctl output")?;
+            Ok(info)
+        }
+        code => {
+            // Special case: if bootctl fails with mentioning `--esp-path` in error output, then we are in testing VM without EFI, handle it and return empty list
+            if err.contains(&"--esp-path") {
+                return Ok(Vec::new());
+            }
+            anyhow::bail!("bootctl failed with exit code {code}, and stderr output: {err}")
+        }
+    }
+}
+
+pub fn find_init(boot_info: &BootctlItem) -> Option<&str> {
+    boot_info
+        .cmdline
+        .split(" ")
+        .find_map(|init| init.strip_prefix("init="))
+}

--- a/crates/ota-update/src/bootctl.rs
+++ b/crates/ota-update/src/bootctl.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -49,7 +50,20 @@ pub async fn get_bootctl_info() -> anyhow::Result<BootctlInfo> {
         .context("bootctl crashed/killed by signal")?
     {
         0 => {
-            let info = serde_json::from_slice(&output.stdout).context("Parsing bootctl output")?;
+            // Design defence:
+            // we have our struct matching only NixOS boot records, so filter out all with sort_key != "nixos" before deserializing
+            // otherwise entries from memtest, dual boot, whatever else break deserializing.
+            let info: Vec<serde_json::Value> =
+                serde_json::from_slice(&output.stdout).context("Parsing bootctl output")?;
+            let info = info
+                .into_iter()
+                .filter(|item| {
+                    item.get("sortKey")
+                        .is_some_and(|val| val.as_str() == Some("nixos"))
+                })
+                .collect();
+            let info =
+                serde_json::from_value(info).context("While decoding bootctl json output")?;
             Ok(info)
         }
         code => {
@@ -62,9 +76,10 @@ pub async fn get_bootctl_info() -> anyhow::Result<BootctlInfo> {
     }
 }
 
-pub fn find_init(boot_info: &BootctlItem) -> Option<&str> {
+pub fn find_init(boot_info: &BootctlItem) -> Option<PathBuf> {
     boot_info
         .cmdline
         .split(" ")
         .find_map(|init| init.strip_prefix("init="))
+        .map(PathBuf::from)
 }

--- a/crates/ota-update/src/lib.rs
+++ b/crates/ota-update/src/lib.rs
@@ -3,3 +3,5 @@ pub mod cli;
 pub mod profile;
 pub mod query;
 pub mod types;
+
+mod nixos;

--- a/crates/ota-update/src/lib.rs
+++ b/crates/ota-update/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bootctl;
 pub mod cli;
 pub mod profile;
 pub mod query;

--- a/crates/ota-update/src/nixos.rs
+++ b/crates/ota-update/src/nixos.rs
@@ -1,0 +1,38 @@
+use anyhow::Context;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Deserialize;
+use std::path::Path;
+use tokio::fs;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NixosVersion {
+    pub nixos_version: String,
+    pub nixpkgs_revision: Option<String>,
+    pub configuration_revision: Option<String>,
+}
+
+static JSON_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?s)cat <<EOF\s*(\{.*?\})\s*EOF"#).expect("Invalid regex"));
+
+pub(crate) async fn read_nixos_version(path: &Path) -> anyhow::Result<NixosVersion> {
+    let path = path.join("sw/bin/nixos-version");
+    let script = fs::read_to_string(&path).await.with_context(|| {
+        format!(
+            "Reading nixos-version script from {path}",
+            path = path.display()
+        )
+    })?;
+    if let Some(caps) = JSON_RE.captures(&script) {
+        let json_str = &caps[1];
+        let version =
+            serde_json::from_str(&json_str).with_context(|| format!("while parsing {json_str}"))?;
+        return Ok(version);
+    } else {
+        anyhow::bail!(
+            "Can't find embedded json with version info in {path}",
+            path = path.display()
+        )
+    }
+}

--- a/crates/ota-update/src/nixos.rs
+++ b/crates/ota-update/src/nixos.rs
@@ -14,7 +14,11 @@ pub(crate) struct NixosVersion {
 }
 
 static JSON_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"(?s)cat <<EOF\s*(\{.*?\})\s*EOF"#).expect("Invalid regex"));
+    Lazy::new(|| Regex::new(r#"(?s)cat <<EOF\s*(\{.*?\})\s*EOF"#).expect("Invalid HEREDOC regex"));
+
+static KERNEL_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\d+\.\d+\.\d+(-[\w\.\+]+)?$").expect("Invalid kernel version regex")
+});
 
 pub(crate) async fn read_nixos_version(path: &Path) -> anyhow::Result<NixosVersion> {
     let path = path.join("sw/bin/nixos-version");
@@ -35,4 +39,29 @@ pub(crate) async fn read_nixos_version(path: &Path) -> anyhow::Result<NixosVersi
             path = path.display()
         )
     }
+}
+
+pub(crate) async fn read_kernel_version(path: &Path) -> anyhow::Result<String> {
+    // Equivalend of $(dirname "/path/to/bzImage") + "/lib/modules"
+    let mod_dir = path
+        .parent()
+        .with_context(|| format!("dirname of {path}", path = path.display()))?
+        .join("lib/modules");
+
+    let mut dir = fs::read_dir(&mod_dir)
+        .await
+        .with_context(|| format!("while read_dir() on {path}", path = mod_dir.display()))?;
+
+    while let Some(entry) = dir.next_entry().await? {
+        let name = entry
+            .file_name()
+            .into_string()
+            .ok()
+            .context("Decode UTF-8 string")?;
+        if KERNEL_RE.is_match(&name) {
+            return Ok(name);
+        }
+    }
+
+    anyhow::bail!("Unable to find kernel version")
 }

--- a/crates/ota-update/src/profile.rs
+++ b/crates/ota-update/src/profile.rs
@@ -1,7 +1,7 @@
 use crate::types::ProfileElement;
 use anyhow::Context;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::process::Command;
 use tracing::{debug, trace};
@@ -26,6 +26,14 @@ pub fn parse_profile_link(profile: &str, link: &str) -> anyhow::Result<i32> {
     Ok(gen_no)
 }
 
+async fn read_symlink(path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+    let symlink = fs::read_link(path)
+        .await
+        .ok()
+        .with_context(|| "While read symlink {path}")?;
+    Ok(symlink)
+}
+
 pub async fn read_profile_links(
     path: &Path,
     profile: &str,
@@ -35,10 +43,7 @@ pub async fn read_profile_links(
         path = path.display()
     );
     let default_link_path = path.join(profile);
-    let default_target = fs::read_link(&default_link_path)
-        .await
-        .ok()
-        .context("reading symlink")?;
+    let default_target = read_symlink(&default_link_path).await?;
     let default_target_str = default_target
         .as_os_str()
         .to_os_string()

--- a/crates/ota-update/src/profile.rs
+++ b/crates/ota-update/src/profile.rs
@@ -1,5 +1,5 @@
 use crate::bootctl::{find_init, get_bootctl_info};
-use crate::nixos::read_nixos_version;
+use crate::nixos::{read_kernel_version, read_nixos_version};
 use crate::types::{GenerationDetails, ProfileElement};
 use anyhow::Context;
 use std::ffi::OsStr;
@@ -122,6 +122,9 @@ pub async fn read_generations() -> anyhow::Result<Vec<GenerationDetails>> {
         let version = read_nixos_version(&bootspec.bootspec.toplevel.0)
             .await
             .context("while read nixos version")?;
+        let kernel_version = read_kernel_version(&bootspec.bootspec.kernel)
+            .await
+            .context("while read kernel version")?;
 
         let bootctl = bootctl
             .iter()
@@ -136,7 +139,7 @@ pub async fn read_generations() -> anyhow::Result<Vec<GenerationDetails>> {
             name: bootspec.bootspec.label.clone(),
             store_path: profile.store_path,
             nixos_version: version.nixos_version,
-            kernel_version: "1.2.3".into(),
+            kernel_version,
             current,
             booted,
             default: profile.current,

--- a/crates/ota-update/src/profile.rs
+++ b/crates/ota-update/src/profile.rs
@@ -4,6 +4,26 @@ use tokio::process::Command;
 
 use anyhow::Context;
 
+pub fn format_profile_link(profile: &str, generation: i32) -> String {
+    format!("{profile}-{generation}-link")
+}
+
+/// Parse profile links like `system-35-link` retrieving generation number
+/// # Errors
+/// Fails if link didn't match given prefix or invalid
+pub fn parse_profile_link(profile: &str, link: &str) -> anyhow::Result<i32> {
+    let gen_no = link
+        .strip_prefix(profile)
+        .with_context(|| format!("'{link}' doesn't start with '{profile}'"))?
+        .strip_prefix("-")
+        .context("missing dash")?
+        .strip_suffix("-link")
+        .context("missing '-link' suffix")?
+        .parse()
+        .context("Unable to parse generation number")?;
+    Ok(gen_no)
+}
+
 /// This function contain isolated call of `nix-env` binary, exclusively to manage
 /// symlinks in /nix/var/nix/profiles
 ///
@@ -24,4 +44,38 @@ pub async fn set(path: &Path, profile: &OsStr, closure: &Path) -> anyhow::Result
         anyhow::bail!("nix-env failed")
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_profile_link() -> anyhow::Result<()> {
+        let system = format_profile_link("system", 42);
+        assert_eq!(parse_profile_link("system", &system)?, 42);
+
+        let bad = parse_profile_link("just", "just-a-link");
+        let err = bad.unwrap_err();
+        assert_eq!(
+            format!("{}", err.root_cause()),
+            "invalid digit found in string"
+        );
+
+        let bad = parse_profile_link("system", "just-a-link");
+        let err = bad.unwrap_err();
+        assert_eq!(
+            format!("{}", err.root_cause()),
+            "'just-a-link' doesn't start with 'system'"
+        );
+
+        let bad = parse_profile_link("system", "system-42-just");
+        let err = bad.unwrap_err();
+        assert_eq!(format!("{}", err.root_cause()), "missing '-link' suffix");
+
+        let bad = parse_profile_link("system", "system42-just");
+        let err = bad.unwrap_err();
+        assert_eq!(format!("{}", err.root_cause()), "missing dash");
+        Ok(())
+    }
 }

--- a/crates/ota-update/src/profile.rs
+++ b/crates/ota-update/src/profile.rs
@@ -1,4 +1,5 @@
-use crate::types::ProfileElement;
+use crate::bootctl::{find_init, get_bootctl_info};
+use crate::types::{GenerationDetails, ProfileElement};
 use anyhow::Context;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -96,6 +97,52 @@ pub async fn read_profile_links(
         });
     }
     Ok((default_gen_no, generations))
+}
+
+pub async fn read_generations() -> anyhow::Result<Vec<GenerationDetails>> {
+    let booted_system = read_symlink(&Path::new("/run/booted-system")).await?;
+    let current_system = read_symlink(&Path::new("/run/current-system")).await?;
+    let bootctl = get_bootctl_info().await?;
+    let (default_num, system_profiles) =
+        read_profile_links(&Path::new("/nix/var/nix/profiles"), "system").await?;
+
+    let mut generations = Vec::new();
+
+    for profile in system_profiles {
+        let bootspec_path = profile.store_path.clone().join("boot.json");
+        let bootspec_json = fs::read_to_string(&bootspec_path).await.with_context(|| {
+            format!(
+                "while reading bootspec {path}",
+                path = bootspec_path.display()
+            )
+        })?;
+        let bootspec: bootspec::v1::GenerationV1 =
+            serde_json::from_str(&bootspec_json).context("while parsing bootspec.json")?;
+
+        let bootctl = bootctl
+            .iter()
+            .find(|bootctl| find_init(&bootctl).as_ref() == Some(&bootspec.bootspec.init))
+            .map(ToOwned::to_owned);
+        let bootable = bootctl.as_ref().is_some_and(|bootctl| bootctl.is_default);
+        let current = profile.store_path == current_system;
+        let booted = profile.store_path == booted_system;
+
+        generations.push(GenerationDetails {
+            generation: profile.num,
+            name: bootspec.bootspec.label.clone(),
+            store_path: profile.store_path,
+            nixos_version: "bogus".into(),
+            kernel_version: "1.2.3".into(),
+            current,
+            booted,
+            default: profile.current,
+            bootable,
+            bootspec,
+            bootctl,
+        });
+    }
+
+    Ok(generations)
 }
 
 /// This function contain isolated call of `nix-env` binary, exclusively to manage

--- a/crates/ota-update/src/profile.rs
+++ b/crates/ota-update/src/profile.rs
@@ -1,4 +1,5 @@
 use crate::bootctl::{find_init, get_bootctl_info};
+use crate::nixos::read_nixos_version;
 use crate::types::{GenerationDetails, ProfileElement};
 use anyhow::Context;
 use std::ffi::OsStr;
@@ -118,6 +119,9 @@ pub async fn read_generations() -> anyhow::Result<Vec<GenerationDetails>> {
         })?;
         let bootspec: bootspec::v1::GenerationV1 =
             serde_json::from_str(&bootspec_json).context("while parsing bootspec.json")?;
+        let version = read_nixos_version(&bootspec.bootspec.toplevel.0)
+            .await
+            .context("while read nixos version")?;
 
         let bootctl = bootctl
             .iter()
@@ -131,7 +135,7 @@ pub async fn read_generations() -> anyhow::Result<Vec<GenerationDetails>> {
             generation: profile.num,
             name: bootspec.bootspec.label.clone(),
             store_path: profile.store_path,
-            nixos_version: "bogus".into(),
+            nixos_version: version.nixos_version,
             kernel_version: "1.2.3".into(),
             current,
             booted,

--- a/crates/ota-update/src/profile.rs
+++ b/crates/ota-update/src/profile.rs
@@ -1,8 +1,10 @@
+use crate::types::ProfileElement;
+use anyhow::Context;
 use std::ffi::OsStr;
 use std::path::Path;
+use tokio::fs;
 use tokio::process::Command;
-
-use anyhow::Context;
+use tracing::{debug, trace};
 
 pub fn format_profile_link(profile: &str, generation: i32) -> String {
     format!("{profile}-{generation}-link")
@@ -22,6 +24,73 @@ pub fn parse_profile_link(profile: &str, link: &str) -> anyhow::Result<i32> {
         .parse()
         .context("Unable to parse generation number")?;
     Ok(gen_no)
+}
+
+pub async fn read_profile_links(
+    path: &Path,
+    profile: &str,
+) -> anyhow::Result<(i32, Vec<ProfileElement>)> {
+    trace!(
+        "Query profiles for {path}, profile {profile}",
+        path = path.display()
+    );
+    let default_link_path = path.join(profile);
+    let default_target = fs::read_link(&default_link_path)
+        .await
+        .ok()
+        .context("reading symlink")?;
+    let default_target_str = default_target
+        .as_os_str()
+        .to_os_string()
+        .into_string()
+        .ok()
+        .context("decode UTF-8 for default profile link")?;
+    let default_gen_no = parse_profile_link(profile, &default_target_str)
+        .with_context(|| "Parsing {default_target_str}")?;
+
+    let mut generations = Vec::new();
+    let mut dir = fs::read_dir(&path)
+        .await
+        .with_context(|| format!("while read_dir() on {path}", path = path.display()))?;
+
+    while let Some(entry) = dir.next_entry().await? {
+        debug!("Processing {entry:?}");
+
+        let name = entry
+            .file_name()
+            .into_string()
+            .ok()
+            .context("Decode UTF-8 string")?;
+
+        // FIXME: could we just skip unparsable items? Items with mismatching `profile` is unparsable
+        if name
+            .strip_prefix(profile)
+            .is_none_or(|f| !f.ends_with("-link"))
+        {
+            continue;
+        }
+
+        let Ok(gen_num) = parse_profile_link(profile, &name) else {
+            trace!("Skip unparsable link {name}");
+            continue;
+        };
+
+        let full_path = entry.path();
+
+        let store_path = match fs::read_link(&full_path).await {
+            Ok(t) if t.is_absolute() && t.exists() => t,
+            _ => continue,
+        };
+
+        let current = default_target_str == name;
+
+        generations.push(ProfileElement {
+            num: gen_num,
+            store_path,
+            current,
+        });
+    }
+    Ok((default_gen_no, generations))
 }
 
 /// This function contain isolated call of `nix-env` binary, exclusively to manage

--- a/crates/ota-update/src/types.rs
+++ b/crates/ota-update/src/types.rs
@@ -11,3 +11,9 @@ pub struct UpdateInfo {
     pub current: bool,
     pub pub_key: String,
 }
+
+pub struct ProfileElement {
+    pub num: i32,
+    pub store_path: PathBuf,
+    pub current: bool,
+}

--- a/crates/ota-update/src/types.rs
+++ b/crates/ota-update/src/types.rs
@@ -17,3 +17,36 @@ pub struct ProfileElement {
     pub store_path: PathBuf,
     pub current: bool,
 }
+
+/// This structure more or less matched output of nixos-rebuild list-generations --json
+/// but extended with some extra information
+///
+/// This intended to pass from `ota-update` to `admin` service in jsoned form
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerationDetails {
+    pub name: String,
+    pub generation: i32,
+    pub nixos_version: String,
+    pub kernel_version: String,
+
+    pub store_path: PathBuf,
+
+    // This generation match /run/current-system
+    pub current: bool,
+
+    // This generation match /run/booted-system
+    pub booted: bool,
+
+    // This generation is next boot candidate in bootctl output
+    pub bootable: bool,
+
+    // This generation match /nix/var/nix/profiles/system default
+    pub default: bool,
+
+    // Raw bootspec data
+    pub bootspec: bootspec::v1::GenerationV1,
+
+    // Raw bootctl info, if generation have matching bootctl record
+    pub bootctl: Option<crate::bootctl::BootctlItem>,
+}


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

Add inspection of boot records of systemd-boot
Enumerating nixos generations moved from executing `nixos-rebuild` to direct scanning of profile links (code generalized, and shared with local updates server)

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
