### PR TITLE
fix(import): Replace gamepad module to jbdemonte

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83
+	github.com/jbdemonte/virtual-device v1.1.1-0.20250823152348-1aea79039990
 	github.com/jochenvg/go-udev v0.0.0-20240801134859-b65ed646224b
 	github.com/linuxkit/virtsock v0.0.0-20241009230534-cb6a20cc0422
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/net v0.43.0
-	github.com/vunnyso/virtual-device v0.0.0-20250813134041-c5338d93c17b
 	golang.org/x/sync v0.16.0
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.7
@@ -26,7 +26,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/jbdemonte/virtual-device v1.1.0 // indirect
 	github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4z
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2/go.mod h1:wd1YpapPLivG6nQgbf7ZkG1hhSOXDhhn4MLTknx2aAc=
 github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83 h1:B+A58zGFuDrvEZpPN+yS6swJA0nzqgZvDzgl/OPyefU=
 github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83/go.mod h1:iHAf8OIncO2gcQ8XOjS7CMJ2aPbX2Bs0wl5pZyanEqk=
-github.com/jbdemonte/virtual-device v1.1.0 h1:CwwJuPDnhx2CEY78pJuI1ZufKRvn0A+wHHWtiQfbnZw=
-github.com/jbdemonte/virtual-device v1.1.0/go.mod h1:5kUPv+50TdhUYqO+2lfoGaSrC1SiE4bj2jR5fFXpH7w=
+github.com/jbdemonte/virtual-device v1.1.1-0.20250823152348-1aea79039990 h1:OO4/4Q4VQaWjq+ANwnHnr2tjzg8vRNbfOkNEB9QmMes=
+github.com/jbdemonte/virtual-device v1.1.1-0.20250823152348-1aea79039990/go.mod h1:5kUPv+50TdhUYqO+2lfoGaSrC1SiE4bj2jR5fFXpH7w=
 github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1 h1:smvLGU3obGU5kny71BtE/ibR0wIXRUiRFDmSn0Nxz1E=
 github.com/jkeiser/iter v0.0.0-20200628201005-c8aa0ae784d1/go.mod h1:fP/NdyhRVOv09PLRbVXrSqHhrfQypdZwgE2L4h2U5C8=
 github.com/jochenvg/go-udev v0.0.0-20240801134859-b65ed646224b h1:Pzf7tldbCVqwl3NnOnTamEWdh/rL41fsoYCn2HdHgRA=
@@ -87,8 +87,6 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
-github.com/vunnyso/virtual-device v0.0.0-20250813134041-c5338d93c17b h1:LCzPP/qE3MZZZW7TXnihoxxWElZU7V1XX3n+5nUk1fk=
-github.com/vunnyso/virtual-device v0.0.0-20250813134041-c5338d93c17b/go.mod h1:Tp+uBD52Qr/pChN6MapNHakpTWjXVDci+b8PUTZYJBQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/modules/pkgs/eventproxy/controller.go
+++ b/modules/pkgs/eventproxy/controller.go
@@ -13,8 +13,8 @@ import (
 	givc_types "givc/modules/pkgs/types"
 
 	evdev "github.com/holoplot/go-evdev"
+	"github.com/jbdemonte/virtual-device/gamepad"
 	"github.com/jochenvg/go-udev"
-	"github.com/vunnyso/virtual-device/gamepad"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/modules/pkgs/eventproxy/transport.go
+++ b/modules/pkgs/eventproxy/transport.go
@@ -15,7 +15,7 @@ import (
 	givc_types "givc/modules/pkgs/types"
 
 	evdev "github.com/holoplot/go-evdev"
-	"github.com/vunnyso/virtual-device/gamepad"
+	"github.com/jbdemonte/virtual-device/gamepad"
 	"google.golang.org/grpc"
 
 	log "github.com/sirupsen/logrus"
@@ -81,7 +81,7 @@ func (s *EventProxyServer) RegisterDevice(ctx context.Context, info *givc_event.
 	}
 
 	if strings.Contains(strings.ToLower(info.Name), "wireless controller") {
-		device := gamepad.NewXBox360()
+		device := gamepad.NewXBoxOneS() // Functionality closer to an actual Xbox controller
 
 		err := device.Register()
 		if err != nil {

--- a/nixos/packages/givc-agent.nix
+++ b/nixos/packages/givc-agent.nix
@@ -8,7 +8,7 @@ pkgs.buildGo124Module {
   inherit pname;
   version = "0.0.5";
   inherit src;
-  vendorHash = "sha256-7kWX6FCkfoKdhwwoei7jr6Jv6JCd68Aq/F0VNs7uZiM=";
+  vendorHash = "sha256-u2+Rl8ZWje8Cbb03+wKBzmApvP9UxfBPUHf6odwtmAU=";
   buildInputs = [ pkgs.systemd ]; # For libudev headers
   subPackages = [
     "modules/cmd/${pname}"


### PR DESCRIPTION

<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description
Replaces the gamepad import path.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [ ] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
