### PR TITLE
fix(admin): Use reported VM name for VM start command argument

### DIFF
--- a/crates/admin/src/admin/server.rs
+++ b/crates/admin/src/admin/server.rs
@@ -486,9 +486,9 @@ impl pb::admin_service_server::AdminService for AdminService {
         request: tonic::Request<StartVmRequest>,
     ) -> std::result::Result<tonic::Response<StartResponse>, tonic::Status> {
         escalate(request, async move |req| {
-            let vm_name = format_vm_name(&req.vm_name, None);
+            let vm_name = format_vm_name("", Some(&req.vm_name));
             self.inner.start_vm(&vm_name).await?;
-            let service_name = format_service_name(&req.vm_name, None);
+            let service_name = format_service_name("", Some(&req.vm_name));
             Ok(StartResponse {
                 registry_id: service_name,
             })

--- a/crates/admin/src/bin/givc-agent.rs
+++ b/crates/admin/src/bin/givc-agent.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use givc::endpoint::TlsConfig;
 use givc::systemd_api::server::SystemdService;
 use givc::types::{EndpointEntry, UnitStatus};
-use givc::utils::naming::format_service_name;
+use givc::utils::naming::VmName;
 use givc_client::AdminClient;
 use givc_common::address::EndpointAddress;
 use givc_common::pb;
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = SocketAddr::new(cli.addr.parse()?, cli.port);
 
     // FIXME: Totally wrong,
-    let agent_service_name = format_service_name(&cli.name, None);
+    let agent_service_name = VmName::App(&cli.name).agent_service();
 
     let mut builder = Server::builder();
 


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

Adjust start_vm to expect argument in same format as is reported by the query.

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [X] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [X] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [X] Author has added reviewers and removed PR draft status

## Testing

Use control panel to stop and start an app VM