### PR TITLE
fix(policy): tuning policy poll interval

### DIFF
--- a/crates/policyadmin/src/policy_repo.rs
+++ b/crates/policyadmin/src/policy_repo.rs
@@ -266,12 +266,8 @@ impl PolicyRepoMonitor {
     #[must_use]
     pub fn start(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
-            let wait_time = if self.poll_interval == Duration::ZERO {
-                Duration::from_secs(300)
-            } else {
-                self.poll_interval
-            };
-
+            /* Retry request every 30 seconds until the first successful response */
+            let mut wait_time = Duration::from_secs(30);
             let mut update_err = false;
 
             loop {
@@ -311,9 +307,11 @@ impl PolicyRepoMonitor {
                     let _ = self.ensure_clone().await;
                     let _ = self.manager.force_update_all_vms();
                     update_err = false;
-                }
-                if self.poll_interval == Duration::ZERO {
-                    return;
+                } else {
+                    wait_time = self.poll_interval;
+                    if self.poll_interval == Duration::ZERO {
+                        return;
+                    }
                 }
                 sleep(wait_time).await;
             }

--- a/crates/policyadmin/src/policy_urls.rs
+++ b/crates/policyadmin/src/policy_urls.rs
@@ -160,6 +160,9 @@ impl PolicyUrlMonitor {
             return Ok(());
         }
 
+        /* Retry request every 30 seconds until the first successful response */
+        let mut wait_time = Duration::from_secs(30);
+
         debug!(
             "policy-url-monitor: [{}] Started. Polling every {}s",
             policy_name, interval
@@ -196,6 +199,7 @@ impl PolicyUrlMonitor {
                     if interval == 0 {
                         return Ok(());
                     }
+                    wait_time = Duration::from_secs(interval);
                 }
                 Ok(None) => {
                     debug!("policy-url-monitor: policy is upto date");
@@ -203,17 +207,14 @@ impl PolicyUrlMonitor {
                     if interval == 0 {
                         return Ok(());
                     }
+                    wait_time = Duration::from_secs(interval);
                 }
                 Err(e) => {
                     error!("policy-url-monitor: [{}] Poll failed: {}", policy_name, e);
                 }
             }
 
-            if interval > 0 {
-                sleep(Duration::from_secs(interval)).await;
-            } else {
-                sleep(Duration::from_secs(30)).await;
-            }
+            sleep(wait_time).await;
         }
     }
 


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description
Reduce policy poll interval to 30 sec until first successful request

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [x] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing
Tested with nixos tests
<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
