### PR TITLE
Update keys in the certificate

### DIFF
--- a/nixos/packages/givc-gen-certs.nix
+++ b/nixos/packages/givc-gen-certs.nix
@@ -23,9 +23,10 @@ pkgs.writeShellScriptBin "gen_mtls_creds" ''
       ca_dir="$output_dir/certification-authority"
       mkdir -p $ca_dir
       ca_constraints="basicConstraints=critical,CA:true,pathlen:1"
+      ca_key_usage="keyUsage=critical,digitalSignature,cRLSign,keyCertSign"
       ca_name="$2"
-      ${pkgs.openssl}/bin/openssl genpkey -algorithm ED25519 -out $ca_dir/ca-key.pem
-      ${pkgs.openssl}/bin/openssl req -x509 -new -key $ca_dir/ca-key.pem -out $ca_dir/ca-cert.pem -subj "/CN=$ca_name" -addext $ca_constraints -days $validity
+      ${pkgs.openssl}/bin/openssl ecparam -genkey -name prime256v1 -out $ca_dir/ca-key.pem
+      ${pkgs.openssl}/bin/openssl req -x509 -new -key $ca_dir/ca-key.pem -out $ca_dir/ca-cert.pem -subj "/CN=$ca_name" -addext "$ca_constraints" -addext "$ca_key_usage" -days $validity
       chown -R root:root "$ca_dir"
       chmod -R 400 $ca_dir
     fi
@@ -42,6 +43,7 @@ pkgs.writeShellScriptBin "gen_mtls_creds" ''
       printf "$name " >> "$output_dir"/agents
       mkdir -p $agent_dir
       ext_key_usage="extendedKeyUsage=serverAuth,clientAuth"
+      key_usage="keyUsage=critical,digitalSignature"
 
       # Initialize DNS and IP entry
       alttext="subjectAltName=DNS.1:''${name}"
@@ -55,10 +57,9 @@ pkgs.writeShellScriptBin "gen_mtls_creds" ''
       done
 
       # Generate and sign key-cert pair
-      ${pkgs.openssl}/bin/openssl genpkey -algorithm ED25519 -out "$agent_dir"/key.pem
-      ${pkgs.openssl}/bin/openssl req -new -key "$agent_dir"/key.pem -out "$agent_dir/$name"-csr.pem -subj "/CN=''${name}" -addext "$alttext" -addext "$ext_key_usage"
-      ${pkgs.openssl}/bin/openssl x509 -req -in "$agent_dir/$name"-csr.pem -CA "$ca_dir"/ca-cert.pem -CAkey "$ca_dir"/ca-key.pem -CAcreateserial -out "$agent_dir"/cert.pem -extfile <(printf "%s" "$alttext") -days $validity
-
+      ${pkgs.openssl}/bin/openssl ecparam -genkey -name prime256v1 -out "$agent_dir"/key.pem
+      ${pkgs.openssl}/bin/openssl req -new -key "$agent_dir"/key.pem -out "$agent_dir/$name"-csr.pem -subj "/CN=''${name}" -addext "$alttext" -addext "$ext_key_usage" -addext "$key_usage"
+      ${pkgs.openssl}/bin/openssl x509 -req -in "$agent_dir/$name"-csr.pem -CA "$ca_dir"/ca-cert.pem -CAkey "$ca_dir"/ca-key.pem -CAcreateserial -out "$agent_dir"/cert.pem -extfile <(printf "%s\n%s\n%s" "$alttext" "$ext_key_usage" "$key_usage") -days $validity
 
       # Delete CSR
       rm "$agent_dir/$name"-csr.pem


### PR DESCRIPTION


<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

- With this modification same certificate can be used for node attestation in spire framework.
- With Ed25519 key, spire can not generate challenge
- Switched to prime256

## Checklist

- [ \x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
