### PR TITLE
GhafSSRCSP-8255: Fix duplicated givc-admin logging

### DIFF
--- a/crates/admin/src/lib.rs
+++ b/crates/admin/src/lib.rs
@@ -22,7 +22,7 @@ pub use givc_common::types;
 pub fn trace_init() -> anyhow::Result<()> {
     use std::env;
     use tracing::Level;
-    use tracing_subscriber::{EnvFilter, Layer, filter::LevelFilter, layer::SubscriberExt};
+    use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt};
 
     let env_filter =
         EnvFilter::try_from_env("GIVC_LOG").unwrap_or_else(|_| EnvFilter::from("info"));
@@ -43,17 +43,19 @@ pub fn trace_init() -> anyhow::Result<()> {
         output.boxed()
     };
 
-    // enable journald logging only on release to avoid log spam on dev machines
-    let journald = match env::var("INVOCATION_ID") {
-        Err(_) => None,
-        Ok(_) => tracing_journald::layer().ok(),
-    };
+    if env::var("INVOCATION_ID").is_ok() {
+        // systemd already captures stderr into journald, so keep a single sink here
+        let journald = tracing_journald::layer()
+            .map(|layer| layer.with_filter(env_filter.clone()).boxed())
+            .unwrap_or(output.with_filter(env_filter).boxed());
 
-    let subscriber = tracing_subscriber::registry()
-        .with(journald.with_filter(LevelFilter::INFO))
-        .with(output.with_filter(env_filter));
-
-    tracing::subscriber::set_global_default(subscriber)
+        tracing::subscriber::set_global_default(tracing_subscriber::registry().with(journald))
+            .context("tracing shouldn't already have been set up")?;
+    } else {
+        tracing::subscriber::set_global_default(
+            tracing_subscriber::registry().with(output.with_filter(env_filter)),
+        )
         .context("tracing shouldn't already have been set up")?;
+    }
     Ok(())
 }

--- a/crates/client/src/endpoint.rs
+++ b/crates/client/src/endpoint.rs
@@ -111,9 +111,22 @@ impl EndpointConfig {
                 .connect()
                 .await
                 .with_context(|| format!("Connecting TCP {url} with {:?}", self.tls))?,
-            EndpointAddress::Unix(unix) => connect_unix_socket(endpoint, unix).await?,
-            EndpointAddress::Abstract(abs) => connect_unix_socket(endpoint, abs).await?,
-            EndpointAddress::Vsock(vs) => connect_vsock_socket(endpoint, *vs).await?,
+            EndpointAddress::Unix(unix) => connect_unix_socket(endpoint, unix)
+                .await
+                .with_context(|| format!("Connecting unix socket {unix} with {:?}", self.tls))?,
+            EndpointAddress::Abstract(abs) => connect_unix_socket(endpoint, abs)
+                .await
+                .with_context(|| format!("Connecting abstract socket {abs} with {:?}", self.tls))?,
+            EndpointAddress::Vsock(vs) => {
+                connect_vsock_socket(endpoint, *vs).await.with_context(|| {
+                    format!(
+                        "Connecting vsock {}:{} with {:?}",
+                        vs.cid(),
+                        vs.port(),
+                        self.tls
+                    )
+                })?
+            }
         };
         Ok(channel)
     }

--- a/crates/client/src/endpoint.rs
+++ b/crates/client/src/endpoint.rs
@@ -12,7 +12,7 @@ use tokio_vsock::{VsockAddr, VsockStream};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, ServerTlsConfig};
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
-use tracing::info;
+use tracing::debug;
 
 use givc_common::address::EndpointAddress;
 use givc_common::types::TransportConfig;
@@ -45,7 +45,7 @@ impl TlsConfig {
         let client_key = std::fs::read(&self.key_file_path)?;
         let client_identity = Identity::from_pem(client_cert, client_key);
         let tls_name = self.tls_name.as_deref().context("Missing TLS name")?;
-        info!("Using TLS name: {tls_name}");
+        debug!("Using TLS name: {tls_name}");
         Ok(ClientTlsConfig::new()
             .ca_certificate(ca)
             .domain_name(tls_name)
@@ -99,7 +99,7 @@ impl EndpointConfig {
     /// Fails if connection failed
     pub async fn connect(&self) -> anyhow::Result<Channel> {
         let url = transport_config_to_url(&self.transport.address, self.tls.is_some());
-        info!("Connecting to {url}, TLS name {:?}", &self.tls);
+        debug!("Connecting to {url}, TLS name {:?}", &self.tls);
         let mut endpoint = Endpoint::try_from(url.clone())?
             .connect_timeout(Duration::from_millis(300))
             .concurrency_limit(30);


### PR DESCRIPTION
## Description

  Fixes GhafSSRCSP-8255 by reducing `givc-admin.service` log spam without losing useful failure diagnostics.

  - Under systemd, use a single journald/stderr sink in `trace_init()` so each log event is emitted once instead of twice.
  - Downgrade successful connection chatter in the client endpoint setup from `INFO` to `DEBUG` to avoid repeated 5-second monitor noise.
  - Add explicit failure context for unix, abstract, and vsock connection attempts so non-TCP dial errors still identify the target endpoint at the default log level.

  ## Checklist

  - [X] Summary of the proposed changes in the PR description
  - [ ] Test procedure added to nixos/tests
  - [ ] Author has run `nix flake check` and it passes
  - [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
  - [ ] Author has added reviewers and removed PR draft status

  ## Testing

  - `cargo fmt --check --all`
  - `nix shell nixpkgs#protobuf -c cargo check -p givc -p givc-client`