### PR TITLE
Fix secureboot status code parsing

### DIFF
--- a/modules/pkgs/statsmanager/controller.go
+++ b/modules/pkgs/statsmanager/controller.go
@@ -340,11 +340,11 @@ func detectSecureBoot() *bool {
 			if !found || !strings.EqualFold(strings.TrimSpace(key), "Secure Boot") {
 				continue
 			}
-			switch strings.ToLower(strings.TrimSpace(value)) {
-			case "enabled":
+			valueLower := strings.ToLower(strings.TrimSpace(value))
+			if strings.Contains(valueLower, "enable") {
 				b := true
 				return &b
-			case "disabled":
+			} else if strings.Contains(valueLower, "disable") {
 				b := false
 				return &b
 			}


### PR DESCRIPTION
sbctl may report secure boot as "enabled (setup)"
change is to check if status contains enable or disable

<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [x] Author has run `nix flake check` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
