### PR TITLE
fix(eventproxy): access control bug fix for event proxy

### DIFF
--- a/modules/cmd/givc-agent/event-service.go
+++ b/modules/cmd/givc-agent/event-service.go
@@ -30,7 +30,7 @@ func StartEventService(ctx context.Context, wg *sync.WaitGroup, config *givc_con
 		}
 
 		// Setup the event proxy server
-		if !eventConfig.Producer {
+		if eventConfig.Consumer.Enable {
 			log.Infof("event: configuring event proxy server: %v", eventConfig)
 
 			wg.Add(1)
@@ -70,7 +70,7 @@ func StartEventService(ctx context.Context, wg *sync.WaitGroup, config *givc_con
 				log.Infof("event: server goroutine finished")
 
 			}(eventConfig)
-		} else {
+		} else if eventConfig.Producer.Enable {
 
 			wg.Add(1)
 			go func(eventConfig givc_types.EventConfig) {

--- a/modules/pkgs/types/types.go
+++ b/modules/pkgs/types/types.go
@@ -51,12 +51,22 @@ type ProxyConfig struct {
 	Socket    string `json:"socket"`
 }
 
+type ProducerConfig struct {
+	Enable bool `json:"enable"`
+}
+
+type ConsumerConfig struct {
+	Enable          bool    `json:"enable"`
+	PermittedSource *string `json:"permittedSource,omitempty"`
+}
+
 // EventConfig represents the configuration for a proxy, including transport settings,
 // whether it is a server, the socket path, and TLS configuration.
 type EventConfig struct {
-	Transport TransportConfig
-	Producer  bool `json:"producer"`
-	Device    string
+	Transport TransportConfig `json:"transport"`
+	Producer  ProducerConfig  `json:"producer"`
+	Consumer  ConsumerConfig  `json:"consumer"`
+	Device    string          `json:"device"`
 }
 
 // Policy configuration

--- a/nixos/modules/appvm.nix
+++ b/nixos/modules/appvm.nix
@@ -223,7 +223,8 @@ in
                   protocol = "tcp";
                 };
                 # producer of input events
-                producer = true;
+                producer.enable = true;
+                consumer.enable = false;
                 device = "wireless controller";
               }
             ];
@@ -324,14 +325,21 @@ in
         ];
       }
     ]
-    ++ optionals cfg.capabilities.eventProxy.enable [
-      {
-        permittedVms = map (p: p.transport.name) cfg.capabilities.eventProxy.events;
-        permittedModules = [
-          "eventproxy"
-        ];
-      }
-    ];
+    ++ optionals cfg.capabilities.eventProxy.enable (
+      let
+        consumerEvents = builtins.filter (
+          e: e.consumer.enable && e.consumer.permittedSource != null
+        ) cfg.capabilities.eventProxy.events;
+      in
+      optionals (consumerEvents != [ ]) [
+        {
+          permittedVms = map (e: e.consumer.permittedSource) consumerEvents;
+          permittedModules = [
+            "eventproxy"
+          ];
+        }
+      ]
+    );
 
     security.polkit = {
       enable = true;

--- a/nixos/modules/definitions.nix
+++ b/nixos/modules/definitions.nix
@@ -411,11 +411,24 @@ in
           Transport configuration of the input proxy module of type `transportSubmodule`.
         '';
       };
-      producer = mkOption {
-        description = ''
-          Whether the module runs as producer or consumer
-        '';
-        type = types.bool;
+      producer = {
+        enable = mkOption {
+          description = "Enable the module to run as a producer.";
+          type = types.bool;
+          default = false;
+        };
+      };
+      consumer = {
+        enable = mkOption {
+          description = "Enable the module to run as a consumer.";
+          type = types.bool;
+          default = false;
+        };
+        permittedSource = mkOption {
+          description = "Name of the VM allowed to send events to this consumer.";
+          type = types.nullOr types.str;
+          default = null;
+        };
       };
       device = mkOption {
         default = "";

--- a/nixos/modules/sysvm.nix
+++ b/nixos/modules/sysvm.nix
@@ -231,7 +231,8 @@ in
                   protocol = "tcp";
                 };
                 # producer of input events
-                producer = true;
+                producer.enable = true;
+                consumer.enable = false;
                 device = "wireless controller";
               }
             ];
@@ -335,14 +336,21 @@ in
         ];
       }
     ]
-    ++ optionals cfg.capabilities.eventProxy.enable [
-      {
-        permittedVms = map (p: p.transport.name) cfg.capabilities.eventProxy.events;
-        permittedModules = [
-          "eventproxy"
-        ];
-      }
-    ];
+    ++ optionals cfg.capabilities.eventProxy.enable (
+      let
+        consumerEvents = builtins.filter (
+          e: e.consumer.enable && e.consumer.permittedSource != null
+        ) cfg.capabilities.eventProxy.events;
+      in
+      optionals (consumerEvents != [ ]) [
+        {
+          permittedVms = map (e: e.consumer.permittedSource) consumerEvents;
+          permittedModules = [
+            "eventproxy"
+          ];
+        }
+      ]
+    );
 
     systemd.targets.givc-setup = {
       enable = true;

--- a/nixos/tests/event.nix
+++ b/nixos/tests/event.nix
@@ -75,6 +75,9 @@ in
 
               givc.sysvm = {
                 enable = true;
+                accessControl = {
+                  enable = true;
+                };
                 network = {
                   admin.transport = lib.head adminConfig.addresses;
                   agent.transport = {
@@ -94,7 +97,8 @@ in
                           port = "9015";
                           protocol = "tcp";
                         };
-                        producer = true;
+                        producer.enable = true;
+                        consumer.enable = false;
                         device = "wireless controller";
                       }
                     ];
@@ -158,6 +162,9 @@ in
 
               givc.appvm = {
                 enable = true;
+                accessControl = {
+                  enable = true;
+                };
                 network = {
                   admin.transport = lib.head adminConfig.addresses;
                   agent.transport = {
@@ -182,7 +189,9 @@ in
                           port = "9015";
                           protocol = "tcp";
                         };
-                        producer = false;
+                        producer.enable = false;
+                        consumer.enable = true;
+                        consumer.permittedSource = "audio-vm";
                       }
                     ];
                   };


### PR DESCRIPTION
<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description
- Added new config to get the producer of the event at consumer side config.
- Write Access control rule to allow the producer of the event.
- enabled access control in `event` test suite to test it.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [x] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [x] Author has added reviewers and removed PR draft status

## Testing

Tested using nixos `event` test.