### PR TITLE
fix(admin): don't log a not-yet-registered service as an error

### DIFF
--- a/crates/admin/src/admin/registry.rs
+++ b/crates/admin/src/admin/registry.rs
@@ -13,6 +13,23 @@ use super::entry::RegistryEntry;
 use crate::types::{UnitStatus, UnitType};
 use crate::utils::naming::parse_vm_name;
 
+/// Marker for "the registry has no entry under this name".
+///
+/// Attached as anyhow context by [`Registry::by_name`] so the error can be
+/// recognised by type rather than by matching on its message. During startup a
+/// client may poll admin for a VM's agent before that VM has registered, which
+/// is expected rather than a fault.
+#[derive(Clone, Debug)]
+pub(crate) struct NotRegistered(pub String);
+
+impl std::fmt::Display for NotRegistered {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Service {} not registered", self.0)
+    }
+}
+
+impl std::error::Error for NotRegistered {}
+
 #[derive(Clone, Debug)]
 pub struct Registry {
     /// The shared state is guarded by a mutex. This is a `std::sync::Mutex` and
@@ -74,7 +91,7 @@ impl Registry {
         state
             .get(name)
             .cloned()
-            .with_context(|| format!("Service {name} not registered"))
+            .with_context(|| NotRegistered(name.to_owned()))
     }
 
     pub(crate) fn find_names(&self, name: &str) -> anyhow::Result<Vec<String>> {

--- a/crates/admin/src/utils/tonic.rs
+++ b/crates/admin/src/utils/tonic.rs
@@ -5,10 +5,23 @@ use anyhow;
 use std::pin::Pin;
 use tonic::{Code, Response, Status};
 use tonic_types::{ErrorDetails, StatusExt};
-use tracing::error;
+use tracing::{debug, error};
+
+use crate::admin::registry::NotRegistered;
 
 pub(crate) type Stream<T> =
     Pin<Box<dyn tokio_stream::Stream<Item = Result<T, Status>> + Send + 'static>>;
+
+/// Is this error just "the caller asked about something not registered yet"?
+///
+/// Must go through `anyhow::Error::downcast_ref`, which knows how to look
+/// inside the layers `.context()` adds. Walking `chain()` and testing each
+/// `&dyn Error` with `is::<NotRegistered>()` does NOT work: the chain yields
+/// anyhow's own wrapper around the context value, so the test is always false
+/// and the classification silently does nothing.
+fn is_expected_miss(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<NotRegistered>().is_some()
+}
 
 // Kludge: wrap_error have .into() semantic, so should be destructive
 // Clippy hint here use &anyhow::Error, but implementing it trigger another clippy warning,
@@ -19,10 +32,17 @@ pub(crate) fn wrap_error(any_err: anyhow::Error) -> tonic::Status {
     let stack: Vec<_> = any_err.chain().skip(1).map(ToString::to_string).collect();
     let cause = any_err.root_cause().to_string();
 
-    // ...then dump them...
-    error!("Local error cause is {cause}");
-    for each in &stack {
-        error!("Local reasons is {each}");
+    // ...then dump them, at a level that matches how alarming they are.
+    if is_expected_miss(&any_err) {
+        debug!("Local error cause is {cause}");
+        for each in &stack {
+            debug!("Local reasons is {each}");
+        }
+    } else {
+        error!("Local error cause is {cause}");
+        for each in &stack {
+            error!("Local reasons is {each}");
+        }
     }
 
     // ...then pack to ErrorDetails
@@ -56,4 +76,33 @@ pub async fn escalate<T, R>(
 ) -> Result<tonic::Response<R>, tonic::Status> {
     let result = fun(req.into_inner()).await;
     result.map(Response::new).wrap_error()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admin::registry::Registry;
+
+    /// The error a client actually provokes by asking about a VM that has not
+    /// registered yet. Built through `Registry`, not by hand, so the test fails
+    /// if `by_name` ever stops attaching the marker.
+    #[test]
+    fn miss_from_registry_is_expected() {
+        let err = Registry::new()
+            .by_name("givc-gui-vm.service")
+            .expect_err("empty registry must not resolve a name");
+        assert!(
+            is_expected_miss(&err),
+            "a registry miss must be classified as expected, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn unrelated_error_is_not_expected() {
+        let err = anyhow::anyhow!("disk on fire").context("while doing something important");
+        assert!(
+            !is_expected_miss(&err),
+            "an unrelated error must keep error-level logging"
+        );
+    }
 }


### PR DESCRIPTION
wrap_error dumps every error's cause chain at error level. A registry lookup that misses is one of those, and during startup it is entirely expected: while a VM is still booting, a client polling admin for that VM's agent gets one miss per attempt. Measured on an SFO laptop, admin-vm logged

  Local error cause is Service givc-gui-vm.service not registered
  Local reasons is  Service givc-gui-vm.service not registered

46 times in the 14 seconds between admin-vm starting and gui-vm's agent registering -- then never again. Loud enough to bury a real error, and it makes a healthy boot read as a broken one.

Mark the miss by type rather than by message: Registry::by_name now attaches a NotRegistered context, and wrap_error logs the whole chain at debug when it finds one anywhere in the chain, error otherwise. The gRPC status is unchanged, so no client-visible behaviour changes -- this is purely about log level.

<!--
    Copyright 2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
#

## Description

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist

<!--
Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item.
-->

- [ ] Summary of the proposed changes in the PR description
- [ ] Test procedure added to nixos/tests
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-givc/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing

<!--
How this was tested by the author? How is this supposed to be tested by people doing system testing?
-->
